### PR TITLE
JZ -  added Leaderboard Feature for totalWealth to be displayed in the desired format

### DIFF
--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -16,6 +16,13 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
         {
             Header: 'Total Wealth',
             accessor: 'totalWealth',
+            //this is the func to  can return custom tableCell
+            Cell : (props)=>{
+            //props.value will contain your date
+            //you can convert total wealth data here
+                const custom_wealth = '$'+props.value.toFixed(2)
+                return <span>{custom_wealth}</span>
+            }
         },
         {
             Header: 'Cows Owned',

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -18,7 +18,7 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
             accessor: 'totalWealth',
             Cell : (props)=>{
                 const custom_wealth = '$'+props.value.toFixed(2)
-                return div style={{textAlign: "right"}}>{custom_wealth}</div>
+                return <div style={{textAlign: "right"}}>{custom_wealth}</div>
             }
         },
         {

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -16,12 +16,9 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
         {
             Header: 'Total Wealth',
             accessor: 'totalWealth',
-            //this is the func to  can return custom tableCell
             Cell : (props)=>{
-            //props.value will contain your date
-            //you can convert total wealth data here
                 const custom_wealth = '$'+props.value.toFixed(2)
-                return <span>{custom_wealth}</span>
+                return div style={{textAlign: "right"}}>{custom_wealth}</div>
             }
         },
         {

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -96,5 +96,21 @@ describe("LeaderboardTable tests", () => {
 
   });
 
+   test("Total wealth is formatted correctly", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <LeaderboardTable leaderboardUsers={leaderboardFixtures.threeUserCommonsLB} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    expect(screen.getAllByText("$1,000.00")[0]).toHaveStyle("text-align: right;");
+
+  });
+
 });
 

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -108,7 +108,7 @@ describe("LeaderboardTable tests", () => {
 
     );
 
-    expect(screen.getAllByText("$1,000.00")[0]).toHaveStyle("text-align: right;");
+    expect(screen.getAllByText("$1000.00")[0]).toHaveStyle("text-align: right;");
 
   });
 

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -82,14 +82,14 @@ describe("LeaderboardTable tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-userId`)).toHaveTextContent("1");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-username`)).toHaveTextContent("one");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-totalWealth`)).toHaveTextContent("1000");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-totalWealth`)).toHaveTextContent("$1000.00");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-cowsBought`)).toHaveTextContent("8");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-cowsSold`)).toHaveTextContent("8");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-cowDeaths`)).toHaveTextContent("8");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-userId`)).toHaveTextContent("2");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-username`)).toHaveTextContent("two");
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-totalWealth`)).toHaveTextContent("1000");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-totalWealth`)).toHaveTextContent("$1000.00");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-cowsBought`)).toHaveTextContent("5");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-cowsSold`)).toHaveTextContent("5");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-cowDeaths`)).toHaveTextContent("5");


### PR DESCRIPTION
Additionally, made changes to   [frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js]
closes issue #11   

[Storybook](https://ucsb-cs156-m23.github.io/proj-happycows-m23-10am-2/prs/16/storybook/?path=/story/components-leaderboard-leaderboardtable--five-user-commons-admin)

![Screenshot (264)](https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-2/assets/102626158/48fd4946-0a93-4eed-b106-176c32485ed5)
