### PR TITLE
ka - fixes the timezone for Milk and Health scheduled jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 | Type | Link       | 
 |------|------------|
-| prod | <https://happycows.dokku-00.cs.ucsb.edu/>     | 
-| qa   | <https://happycows-qa.dokku-00.cs.ucsb.edu/>  | 
+| prod | <https://proj-happycows.dokku-05.cs.ucsb.edu/>     | 
+| qa   | <https://proj-happycows-qa.dokku-05.cs.ucsb.edu/>  | 
 
 # Description
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
@@ -34,7 +34,7 @@ public class ScheduledJobs {
     @Autowired
     MilkTheCowsJobFactory milkTheCowsJobFactory;
     
-    @Scheduled(cron = "${app.updateCowHealth.cron, zone = America/Los_Angeles}")
+    @Scheduled(cron = "${app.updateCowHealth.cron}", zone = "America/Los_Angeles")
     public void runUpdateCowHealthJobBasedOnCron() {
        log.info("runUpdateCowHealthJobBasedOnCron: running");
 
@@ -44,7 +44,7 @@ public class ScheduledJobs {
        log.info("runUpdateCowHealthJobBasedOnCron: launched job");
     }
 
-    @Scheduled(cron = "${app.milkTheCows.cron, zone = America/Los_Angeles}")
+    @Scheduled(cron = "${app.milkTheCows.cron}", zone = "America/Los_Angeles")
     public void runMilkTheCowsJobBasedOnCron() {
        log.info("runMilkTheCowsJobBasedOnCron: running");
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
@@ -34,7 +34,7 @@ public class ScheduledJobs {
     @Autowired
     MilkTheCowsJobFactory milkTheCowsJobFactory;
     
-    @Scheduled(cron = "${app.updateCowHealth.cron}")
+    @Scheduled(cron = "${app.updateCowHealth.cron, zone = America/Los_Angeles}")
     public void runUpdateCowHealthJobBasedOnCron() {
        log.info("runUpdateCowHealthJobBasedOnCron: running");
 
@@ -44,7 +44,7 @@ public class ScheduledJobs {
        log.info("runUpdateCowHealthJobBasedOnCron: launched job");
     }
 
-    @Scheduled(cron = "${app.milkTheCows.cron}")
+    @Scheduled(cron = "${app.milkTheCows.cron, zone = America/Los_Angeles}")
     public void runMilkTheCowsJobBasedOnCron() {
        log.info("runMilkTheCowsJobBasedOnCron: running");
 


### PR DESCRIPTION
Fixes the issue with the jobs being performed with a 5-hour delay by specifying the timezone to Los_Angeles.

Deployed on https://proj-happycows-kirrarista.dokku-05.cs.ucsb.edu/ for testing. (I would wait until Tuesday morning to see if the scheduled updates happen on time. It will be shown in Admin -> Manage Jobs)

Closes #4 
