### PR TITLE
ka - adds a warning window popping up upon attempting to delete a commons

### DIFF
--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -111,10 +111,10 @@ export default function CommonsTable({ commons, currentUser }) {
         This is your last chance to keep this commons. If you choose to delete it, it will be gone forever.
         </Modal.Body>
         <Modal.Footer>
-        <Button variant="primary" onClick={handleClose} data-testid={`cancel-delete-button-row-${cellToDelete.row.index}-col-${cellToDelete.column.id}-button`}>
+        <Button variant="primary" onClick={handleClose} data-testid={`cancel-delete-button`}>
         Keep this Commons
         </Button>
-        <Button variant="danger" onClick={() => { deleteMutation.mutate(cellToDelete); handleClose()}} data-testid={`confirm-delete-button-row-${cellToDelete.row.index}-col-${cellToDelete.column.id}-button`}>
+        <Button variant="danger" onClick={() => { deleteMutation.mutate(cellToDelete); handleClose()}} data-testid={`confirm-delete-button`}>
         Permanently Delete
             </Button>
         </Modal.Footer>

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -19,8 +19,8 @@ export default function CommonsTable({ commons, currentUser }) {
         ["/api/commons/allplus"]
     );
 
-    const deleteCallback = async (cell) => { 
-        deleteMutation.mutate(cell); 
+    const deleteCallback = async (cell) => {
+        deleteMutation.mutateAsync(cell);
     }
 
     const leaderboardCallback = (cell) => {

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -1,11 +1,18 @@
-import React from "react";
+import React, { useState } from "react";
 import OurTable, {ButtonColumn} from "main/components/OurTable";
 import { useBackendMutation } from "main/utils/useBackend";
 import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/commonsUtils"
 import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
+import Button from 'react-bootstrap/Button';
+import Modal from 'react-bootstrap/Modal';
 
 export default function CommonsTable({ commons, currentUser }) {
+    const [show, setShow] = useState(false);
+    const [cellToDelete, setCellToDelete] = useState(null);
+
+    const handleClose = () => setShow(false);
+    const handleShow = () => setShow(true);
 
     const navigate = useNavigate();
 
@@ -20,7 +27,8 @@ export default function CommonsTable({ commons, currentUser }) {
     );
 
     const deleteCallback = async (cell) => {
-        deleteMutation.mutateAsync(cell);
+        setCellToDelete(cell);
+        handleShow();
     }
 
     const leaderboardCallback = (cell) => {
@@ -82,19 +90,43 @@ export default function CommonsTable({ commons, currentUser }) {
 
     const columnsIfAdmin = [
         ...columns,
-        ButtonColumn("Edit",
-"primary", editCallback, testid),
-        ButtonColumn("Delete",
-"danger", deleteCallback, testid),
-        ButtonColumn("Leaderboard",
-"secondary", leaderboardCallback, testid)
+        ButtonColumn("Edit", "primary", editCallback, testid),
+        ButtonColumn("Delete", "danger", deleteCallback, testid),
+        ButtonColumn("Leaderboard", "secondary", leaderboardCallback, testid)
     ];
 
     const columnsToDisplay = hasRole(currentUser,"ROLE_ADMIN") ? columnsIfAdmin : columns;
 
-    return <OurTable
+    const modalForm = (<Modal
+        show={show}
+        onHide={handleClose}
+        backdrop="static"
+        keyboard={false}
+        data-testid="delete-modal"
+    >
+        <Modal.Header closeButton>
+        <Modal.Title>Are you sure you want to delete this commons?</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+        This is your last chance to keep this commons. If you choose to delete it, it will be gone forever.
+        </Modal.Body>
+        <Modal.Footer>
+        <Button variant="primary" onClick={handleClose} data-testid={`cancel-delete-button-row-${cellToDelete.row.index}-col-${cellToDelete.column.id}-button`}>
+        Keep this Commons
+        </Button>
+        <Button variant="danger" onClick={() => { deleteMutation.mutate(cellToDelete); handleClose()}} data-testid={`confirm-delete-button-row-${cellToDelete.row.index}-col-${cellToDelete.column.id}-button`}>
+        Permanently Delete
+            </Button>
+        </Modal.Footer>
+  </Modal>);
+
+    return (
+    <>
+        <OurTable
         data={commons}
         columns={columnsToDisplay}
         testid={testid}
-    />;
+        />
+        {modalForm}
+    </>);
 };

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -101,7 +101,6 @@ export default function CommonsTable({ commons, currentUser }) {
         show={show}
         onHide={handleClose}
         backdrop="static"
-        keyboard={false}
         data-testid="delete-modal"
     >
         <Modal.Header closeButton>

--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -1,8 +1,7 @@
-import React, { useState } from 'react';
+import React from "react";
 import { useTable, useSortBy } from 'react-table'
-import { Table, Button, Modal } from "react-bootstrap";
+import { Table, Button } from "react-bootstrap";
 import Plaintext from "main/components/Utils/Plaintext";
-
 // Stryker disable all
 var tableStyle = {
   "background": "white",
@@ -101,52 +100,17 @@ export default function OurTable({ columns, data, testid = "testid", ...rest }) 
 // ];
 
 export function ButtonColumn(label, variant, callback, testid) {
-  const [show, setShow] = useState(false);
-
-  const handleClose = () => setShow(false);
-  const handleShow = () => setShow(true);
-
   const column = {
     Header: label,
     id: label,
     Cell: ({ cell }) => (
-      <>
-        <Button
-          variant={variant}
-          onClick={() => {
-            if (label === "Delete") {
-              handleShow();
-            } else {
-              callback(cell);
-            }}
-          }
-          data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-button`}
-        >
-          {label}
-        </Button>
-        <Modal
-          show={show}
-          onHide={handleClose}
-          backdrop="static"
-          keyboard={false}
-          data-testid="delete-modal"
-        >
-          <Modal.Header closeButton>
-            <Modal.Title>Are you sure you want to delete this commons?</Modal.Title>
-          </Modal.Header>
-          <Modal.Body>
-            This is your last chance to keep this commons. If you choose to delete it, it will be gone forever.
-          </Modal.Body>
-          <Modal.Footer>
-            <Button variant="primary" onClick={handleClose} data-testid={`cancel-delete-button-row-${cell.row.index}-col-${cell.column.id}-button`}>
-            Keep this Commons
-            </Button>
-            <Button variant="danger" onClick={() => { callback(cell); handleClose()}} data-testid={`confirm-delete-button-row-${cell.row.index}-col-${cell.column.id}-button`}>
-            Permanently Delete
-              </Button>
-          </Modal.Footer>
-        </Modal>
-      </>
+      <Button
+        variant={variant}
+        onClick={() => callback(cell)}
+        data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-button`}
+      >
+        {label}
+      </Button>
     )
   }
   return column;

--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -114,11 +114,10 @@ export function ButtonColumn(label, variant, callback, testid) {
         <Button
           variant={variant}
           onClick={() => {
-            if (label === "Edit") {
-              callback(cell);
-            }
-            else if (label === "Delete") {
+            if (label === "Delete") {
               handleShow();
+            } else {
+              callback(cell);
             }}
           }
           data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-button`}
@@ -130,6 +129,7 @@ export function ButtonColumn(label, variant, callback, testid) {
           onHide={handleClose}
           backdrop="static"
           keyboard={false}
+          data-testid="delete-modal"
         >
           <Modal.Header closeButton>
             <Modal.Title>Are you sure you want to delete this commons?</Modal.Title>
@@ -138,10 +138,10 @@ export function ButtonColumn(label, variant, callback, testid) {
             This is your last chance to keep this commons. If you choose to delete it, it will be gone forever.
           </Modal.Body>
           <Modal.Footer>
-            <Button variant="primary" onClick={handleClose}>
+            <Button variant="primary" onClick={handleClose} data-testid={`cancel-delete-button-row-${cell.row.index}-col-${cell.column.id}-button`}>
             Keep this Commons
             </Button>
-            <Button variant="danger" onClick={() => { callback(cell); handleClose()}}>
+            <Button variant="danger" onClick={() => { callback(cell); handleClose()}} data-testid={`confirm-delete-button-row-${cell.row.index}-col-${cell.column.id}-button`}>
             Permanently Delete
               </Button>
           </Modal.Footer>

--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -1,4 +1,4 @@
-import { React, useState } from 'react';
+import React, { useState } from 'react';
 import { useTable, useSortBy } from 'react-table'
 import { Table, Button, Modal } from "react-bootstrap";
 import Plaintext from "main/components/Utils/Plaintext";

--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -1,7 +1,8 @@
-import React from "react";
+import { React, useState } from 'react';
 import { useTable, useSortBy } from 'react-table'
-import { Table, Button } from "react-bootstrap";
+import { Table, Button, Modal } from "react-bootstrap";
 import Plaintext from "main/components/Utils/Plaintext";
+
 // Stryker disable all
 var tableStyle = {
   "background": "white",
@@ -100,17 +101,52 @@ export default function OurTable({ columns, data, testid = "testid", ...rest }) 
 // ];
 
 export function ButtonColumn(label, variant, callback, testid) {
+  const [show, setShow] = useState(false);
+
+  const handleClose = () => setShow(false);
+  const handleShow = () => setShow(true);
+
   const column = {
     Header: label,
     id: label,
     Cell: ({ cell }) => (
-      <Button
-        variant={variant}
-        onClick={() => callback(cell)}
-        data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-button`}
-      >
-        {label}
-      </Button>
+      <>
+        <Button
+          variant={variant}
+          onClick={() => {
+            if (label === "Edit") {
+              callback(cell);
+            }
+            else if (label === "Delete") {
+              handleShow();
+            }}
+          }
+          data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-button`}
+        >
+          {label}
+        </Button>
+        <Modal
+          show={show}
+          onHide={handleClose}
+          backdrop="static"
+          keyboard={false}
+        >
+          <Modal.Header closeButton>
+            <Modal.Title>Are you sure you want to delete this commons?</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            This is your last chance to keep this commons. If you choose to delete it, it will be gone forever.
+          </Modal.Body>
+          <Modal.Footer>
+            <Button variant="primary" onClick={handleClose}>
+            Keep this Commons
+            </Button>
+            <Button variant="danger" onClick={() => { callback(cell); handleClose()}}>
+            Permanently Delete
+              </Button>
+          </Modal.Footer>
+        </Modal>
+      </>
     )
   }
   return column;

--- a/frontend/src/tests/pages/AdminListCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminListCommonsPage.test.js
@@ -132,10 +132,26 @@ describe("AdminListCommonPage tests", () => {
         expect(await screen.findByTestId(`${testId}-cell-row-0-col-commons.id`)).toBeInTheDocument();
         expect(screen.getByTestId(`${testId}-cell-row-0-col-commons.id`)).toHaveTextContent("1"); 
 
+        const deleteButton2 = screen.getByTestId(`${testId}-cell-row-2-col-Delete-button`);
+        expect(deleteButton2).toBeInTheDocument();
+       
+        fireEvent.click(deleteButton2);
+
+        expect(await screen.findAllByTestId("delete-modal")).toHaveLength(3);
+        const cancelButton = screen.getByTestId(`cancel-delete-button-row-0-col-Delete-button`);
+
+        fireEvent.click(cancelButton);
+        
+        expect(screen.queryByTestId(`delete-modal`)).not.toBeInTheDocument();   
         const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
         expect(deleteButton).toBeInTheDocument();
        
         fireEvent.click(deleteButton);
+
+        expect(await screen.findAllByTestId("delete-modal")).toHaveLength(3);
+        const confirmDeleteButton = screen.getByTestId(`confirm-delete-button-row-0-col-Delete-button`);
+
+        fireEvent.click(confirmDeleteButton);
 
         await waitFor(() => { expect(mockToast).toBeCalledWith("Commons with id 1 was deleted") });
     });

--- a/frontend/src/tests/pages/AdminListCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminListCommonsPage.test.js
@@ -137,19 +137,18 @@ describe("AdminListCommonPage tests", () => {
        
         fireEvent.click(deleteButton2);
 
-        expect(await screen.findAllByTestId("delete-modal")).toHaveLength(3);
-        const cancelButton = screen.getByTestId(`cancel-delete-button-row-0-col-Delete-button`);
+        expect(await screen.findByTestId("delete-modal")).toBeInTheDocument();
+        const cancelButton = screen.getByTestId(`cancel-delete-button`);
 
         fireEvent.click(cancelButton);
         
-        expect(screen.queryByTestId(`delete-modal`)).not.toBeInTheDocument();   
         const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
         expect(deleteButton).toBeInTheDocument();
        
         fireEvent.click(deleteButton);
 
-        expect(await screen.findAllByTestId("delete-modal")).toHaveLength(3);
-        const confirmDeleteButton = screen.getByTestId(`confirm-delete-button-row-0-col-Delete-button`);
+        expect(await screen.findByTestId("delete-modal")).toBeInTheDocument();
+        const confirmDeleteButton = screen.getByTestId(`confirm-delete-button`);
 
         fireEvent.click(confirmDeleteButton);
 

--- a/frontend/src/tests/pages/AdminListCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminListCommonsPage.test.js
@@ -134,20 +134,24 @@ describe("AdminListCommonPage tests", () => {
 
         const deleteButton2 = screen.getByTestId(`${testId}-cell-row-2-col-Delete-button`);
         expect(deleteButton2).toBeInTheDocument();
-       
+        expect(document.body).not.toContainElement(screen.queryByTestId(`delete-modal`));
+
         fireEvent.click(deleteButton2);
 
-        expect(await screen.findByTestId("delete-modal")).toBeInTheDocument();
+        expect(await screen.findByTestId(`delete-modal`)).toBeInTheDocument();
+        expect(document.body).toContainElement(screen.queryByTestId(`delete-modal`));
         const cancelButton = screen.getByTestId(`cancel-delete-button`);
 
         fireEvent.click(cancelButton);
         
+        await waitFor(() => { expect(document.body).not.toContainElement(screen.queryByTestId(`delete-modal`)) });
         const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
         expect(deleteButton).toBeInTheDocument();
        
         fireEvent.click(deleteButton);
 
-        expect(await screen.findByTestId("delete-modal")).toBeInTheDocument();
+        expect(await screen.findByTestId(`delete-modal`)).toBeInTheDocument();
+        expect(document.body).toContainElement(screen.queryByTestId(`delete-modal`));
         const confirmDeleteButton = screen.getByTestId(`confirm-delete-button`);
 
         fireEvent.click(confirmDeleteButton);


### PR DESCRIPTION
Adds a warning window making sure an admin doesn't accidentally delete a commons.

<img width="1164" alt="image" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-2/assets/77711406/b8c1921a-8825-4bdd-84f6-7aac6a174cd0">

To test: Go to https://proj-happycows-kirrarista.dokku-05.cs.ucsb.edu/ -> Admin -> List Commons -> Click Delete

Closes #1 