### PR TITLE
RG - Added CapacityPerUser field to Commons Edit/Create/List Page (pt. 1 of Issue #8)

### DIFF
--- a/frontend/src/fixtures/commonsFixtures.js
+++ b/frontend/src/fixtures/commonsFixtures.js
@@ -12,6 +12,7 @@ const commonsFixtures = {
             "degradationRate": .5,
             "showLeaderboard": true,
             "carryingCapacity": 100,
+            "capacityPerUser": 105,
             "belowCapacityHealthUpdateStrategy": "Noop",
             "aboveCapacityHealthUpdateStrategy": "Noop"
         },
@@ -27,6 +28,7 @@ const commonsFixtures = {
             "degradationRate": .5,
             "showLeaderboard": true,
             "carryingCapacity": 123,
+            "capacityPerUser": 110,
             "belowCapacityHealthUpdateStrategy": "Linear",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -42,6 +44,7 @@ const commonsFixtures = {
             "degradationRate": .5,
             "showLeaderboard": true,
             "carryingCapacity": 42,
+            "capacityPerUser": 115,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         }
@@ -60,6 +63,7 @@ const commonsFixtures = {
                 "degradationRate": .5,
                 "showLeaderboard": true,
                 "carryingCapacity": 314,
+                "capacityPerUser": 120,
                 "belowCapacityHealthUpdateStrategy": "Constant",
                 "aboveCapacityHealthUpdateStrategy": "Linear"
             }
@@ -75,6 +79,7 @@ const commonsFixtures = {
             "degradationRate": .5,
             "showLeaderboard": true,
             "carryingCapacity": 100,
+            "capacityPerUser": 125,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -87,6 +92,7 @@ const commonsFixtures = {
             "degradationRate": .5,
             "showLeaderboard": true,
             "carryingCapacity": 100,
+            "capacityPerUser": 130,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -99,6 +105,7 @@ const commonsFixtures = {
             "degradationRate": .5,
             "showLeaderboard": true,
             "carryingCapacity": 100,
+            "capacityPerUser": 135,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -111,6 +118,7 @@ const commonsFixtures = {
             "degradationRate": .5,
             "showLeaderboard": true,
             "carryingCapacity": 100,
+            "capacityPerUser": 140,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -123,6 +131,7 @@ const commonsFixtures = {
             "degradationRate": .5,
             "showLeaderboard": true,
             "carryingCapacity": 100,
+            "capacityPerUser": 145,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -135,6 +144,7 @@ const commonsFixtures = {
             "degradationRate": .5,
             "showLeaderboard": true,
             "carryingCapacity": 100,
+            "capacityPerUser": 150,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -147,6 +157,7 @@ const commonsFixtures = {
             "degradationRate": .5,
             "showLeaderboard": true,
             "carryingCapacity": 100,
+            "capacityPerUser": 155,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         }

--- a/frontend/src/fixtures/commonsPlusFixtures.js
+++ b/frontend/src/fixtures/commonsPlusFixtures.js
@@ -12,6 +12,7 @@ const commonsPlusFixtures = {
                 "degradationRate": 0.01,
                 "showLeaderboard": false,
                 "carryingCapacity": 100,
+                "capacityPerUser": 105,
             },
             "totalCows": 10,
             "totalUsers": 2
@@ -29,6 +30,7 @@ const commonsPlusFixtures = {
                 "degradationRate": 0.01,
                 "showLeaderboard": true,
                 "carryingCapacity": 42,
+                "capacityPerUser": 110,
             },
             "totalCows": 0,
             "totalUsers": 1
@@ -46,6 +48,7 @@ const commonsPlusFixtures = {
                 "degradationRate": 5.0,
                 "showLeaderboard": true,
                 "carryingCapacity": 123,
+                "capacityPerUser": 115,
             },
             "totalCows": 0,
             "totalUsers": 1
@@ -66,6 +69,7 @@ const commonsPlusFixtures = {
                 "degradationRate": 3.0,
                 "showLeaderboard": false,
                 "carryingCapacity": 23,
+                "capacityPerUser": 120,
             },
             "totalCows": 0,
             "totalUsers": 0

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -178,7 +178,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
           id="capacityPerUser"
           type="number"
           step="1"
-          isInvalid={!!errors.carryingCapacity}
+          isInvalid={!!errors.capacityPerUser}
           {...register("capacityPerUser", {
             valueAsNumber: true,
             required: "Capacity Per User is required",

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -171,6 +171,25 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
         </Form.Control.Feedback>
       </Form.Group>
 
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="capacityPerUser">Capacity Per User</Form.Label>
+        <Form.Control
+          data-testid={`${testid}-capacityPerUser`}
+          id="capacityPerUser"
+          type="number"
+          step="1"
+          isInvalid={!!errors.carryingCapacity}
+          {...register("capacityPerUser", {
+            valueAsNumber: true,
+            required: "Capacity Per User is required",
+            min: {value: 1, message: "Capacity Per User must be ≥ 1"},
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.capacityPerUser?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
       <h4>
         Health update formula
       </h4>

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -75,6 +75,11 @@ export default function CommonsTable({ commons, currentUser }) {
             Header: 'Carrying Capacity',
             accessor: row => row.commons.carryingCapacity,
             id: 'commons.carryingCapacity'
+        },
+        { //#8
+            Header: 'Capacity Per User',
+            accessor: row => row.commons.capacityPerUser,
+            id: 'commons.capacityPerUser'
         }
     ];
 

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -76,7 +76,7 @@ export default function CommonsTable({ commons, currentUser }) {
             accessor: row => row.commons.carryingCapacity,
             id: 'commons.carryingCapacity'
         },
-        { //#8
+        {
             Header: 'Capacity Per User',
             accessor: row => row.commons.capacityPerUser,
             id: 'commons.capacityPerUser'

--- a/frontend/src/main/pages/AdminCreateCommonsPage.js
+++ b/frontend/src/main/pages/AdminCreateCommonsPage.js
@@ -21,6 +21,7 @@ const AdminCreateCommonsPage = () => {
             <br />{`startDate: ${commons.startingDate}`}
             <br />{`cowPrice: ${commons.cowPrice}`}
             <br />{`carryingCapacity: ${commons.carryingCapacity}`}
+            <br />{`capacityPerUser: ${commons.capacityPerUser}`}
         </div>);
     }
    

--- a/frontend/src/main/pages/AdminEditCommonsPage.js
+++ b/frontend/src/main/pages/AdminEditCommonsPage.js
@@ -36,10 +36,10 @@ export default function CommonsEditPage() {
         "startingDate": commons.startingDate,
         "degradationRate": commons.degradationRate,
         "carryingCapacity": commons.carryingCapacity,
+        "capacityPerUser": commons.capacityPerUser,
         "aboveCapacityHealthUpdateStrategy": commons.aboveCapacityHealthUpdateStrategy,
         "belowCapacityHealthUpdateStrategy": commons.belowCapacityHealthUpdateStrategy,
         "showLeaderboard": commons.showLeaderboard,
-        "capacityPerUser": commons.capacityPerUser,
     }
   });
 

--- a/frontend/src/main/pages/AdminEditCommonsPage.js
+++ b/frontend/src/main/pages/AdminEditCommonsPage.js
@@ -39,6 +39,7 @@ export default function CommonsEditPage() {
         "aboveCapacityHealthUpdateStrategy": commons.aboveCapacityHealthUpdateStrategy,
         "belowCapacityHealthUpdateStrategy": commons.belowCapacityHealthUpdateStrategy,
         "showLeaderboard": commons.showLeaderboard,
+        "capacityPerUser": commons.capacityPerUser,
     }
   });
 

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -10,7 +10,6 @@ import { useBackend } from "main/utils/useBackend";
 import { useCurrentUser } from "main/utils/currentUser";
 import Background from "../../assets/PlayPageBackground.png";
 
-//#12
 import { Button } from 'react-bootstrap';
 import { useNavigate } from 'react-router-dom';
 
@@ -21,7 +20,6 @@ export default function LeaderboardPage() {
   const { commonsId } = useParams();
   const { data: currentUser } = useCurrentUser();
 
-  //#12
   const navigate = useNavigate();
 
   // Stryker disable all 
@@ -60,7 +58,7 @@ export default function LeaderboardPage() {
         <BasicLayout>
             <div className="pt-2">
                 <Button
-                  variant="danger"
+                  variant="secondary"
                   onClick={() => navigate(-1)}
                   data-testid={"Leaderboard-back"}
                 >

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -62,7 +62,7 @@ export default function LeaderboardPage() {
                 <Button
                   variant="outline-danger"
                   onClick={() => navigate(-1)}
-                  data-testid={"Leaderboard-cancel"}
+                  data-testid={"Leaderboard-back"}
                 >
                   Back
                 </Button>

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -60,7 +60,7 @@ export default function LeaderboardPage() {
         <BasicLayout>
             <div className="pt-2">
                 <Button
-                  variant="outline-danger"
+                  variant="danger"
                   onClick={() => navigate(-1)}
                   data-testid={"Leaderboard-back"}
                 >

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -10,11 +10,19 @@ import { useBackend } from "main/utils/useBackend";
 import { useCurrentUser } from "main/utils/currentUser";
 import Background from "../../assets/PlayPageBackground.png";
 
+//#12
+import { Button } from 'react-bootstrap';
+import { useNavigate } from 'react-router-dom';
+
+
 
 export default function LeaderboardPage() {
 
   const { commonsId } = useParams();
   const { data: currentUser } = useCurrentUser();
+
+  //#12
+  const navigate = useNavigate();
 
   // Stryker disable all 
   const { data: userCommons, error: _error, status: _status } =
@@ -51,6 +59,13 @@ export default function LeaderboardPage() {
     <div data-testid={"LeaderboardPage-main-div"} style={{backgroundSize: 'cover', backgroundImage: `url(${Background})`}}>
         <BasicLayout>
             <div className="pt-2">
+                <Button
+                  variant="outline-danger"
+                  onClick={() => navigate(-1)}
+                  data-testid={"Leaderboard-cancel"}
+                >
+                  Back
+                </Button>
                 <h1>Leaderboard</h1>
                 {
                   showLeaderboard?

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -51,6 +51,7 @@ describe("CommonsForm tests", () => {
       /Show Leaderboard\?/,
       /When below capacity/,
       /When above capacity/,
+      /Capacity Per User/,
 
     ].forEach(
       (pattern) => {
@@ -93,6 +94,7 @@ describe("CommonsForm tests", () => {
     expect(screen.getByText(/starting date is required/i)).toBeInTheDocument();
     expect(screen.getByText(/degradation rate is required/i)).toBeInTheDocument();
     expect(screen.getByText(/Carrying capacity is required/i)).toBeInTheDocument();
+    expect(screen.getByText(/Capacity Per User is required/i)).toBeInTheDocument();
 
     // check that each of the fields that has 
     // a validation error is marked as invalid
@@ -107,6 +109,7 @@ describe("CommonsForm tests", () => {
       "CommonsForm-startingDate",
       "CommonsForm-degradationRate",
       "CommonsForm-carryingCapacity",
+      "CommonsForm-capacityPerUser",
     ].forEach(
       (testid) => {
         const element = screen.getByTestId(testid);
@@ -170,6 +173,10 @@ describe("CommonsForm tests", () => {
     fireEvent.change(screen.getByTestId("CommonsForm-carryingCapacity"), { target: { value: "-1" } });
     fireEvent.click(submitButton);
     await screen.findByText(/Carrying Capacity must be ≥ 1/i);
+
+    fireEvent.change(screen.getByTestId("CommonsForm-capacityPerUser"), { target: { value: "-1" } });
+    fireEvent.click(submitButton);
+    await screen.findByText(/Capacity Per User must be ≥ 1/i);
 
 
     expect(submitAction).not.toBeCalled();

--- a/frontend/src/tests/components/Commons/CommonsTable.test.js
+++ b/frontend/src/tests/components/Commons/CommonsTable.test.js
@@ -69,8 +69,8 @@ describe("UserTable tests", () => {
 
     );
 
-    const expectedHeaders = ["id", "Name", "Cow Price", 'Milk Price', 'Starting Balance', 'Starting Date', 'Degradation Rate', 'Carrying Capacity', 'Cows', 'Show Leaderboard?'];
-    const expectedFields = ["id", "name", "cowPrice", "milkPrice", "startingBalance", "startingDate", "degradationRate", "carryingCapacity"];
+    const expectedHeaders = ["id", "Name", "Cow Price", 'Milk Price', 'Starting Balance', 'Starting Date', 'Degradation Rate', 'Carrying Capacity', 'Capacity Per User', 'Cows', 'Show Leaderboard?'];
+    const expectedFields = ["id", "name", "cowPrice", "milkPrice", "startingBalance", "startingDate", "degradationRate", "carryingCapacity", "capacityPerUser"];
     const testId = "CommonsTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -92,6 +92,7 @@ describe("UserTable tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.milkPrice`)).toHaveTextContent("2");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.degradationRate`)).toHaveTextContent("0.01");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.carryingCapacity`)).toHaveTextContent("42");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.capacityPerUser`)).toHaveTextContent("110");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.startingBalance`)).toHaveTextContent("10");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.startingDate`)).toHaveTextContent(/^2022-11-22$/); // regex so that we have an exact match https://stackoverflow.com/a/73298371
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.showLeaderboard`)).toHaveTextContent("true");

--- a/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminCreateCommonsPage.test.js
@@ -65,6 +65,7 @@ describe("AdminCreateCommonsPage tests", () => {
             "startingDate": "2022-03-05T00:00:00",
             "degradationRate": 30.4,
             "carryingCapacity": 25,
+            "capacityPerUser": 26,
             "aboveCapacityHealthUpdateStrategy": "strat2",
             "belowCapacityHealthUpdateStrategy": "strat3",
             "showLeaderboard": false,
@@ -87,6 +88,7 @@ describe("AdminCreateCommonsPage tests", () => {
         const startDateField = screen.getByLabelText("Starting Date");
         const degradationRateField = screen.getByLabelText("Degradation Rate");
         const carryingCapacityField = screen.getByLabelText("Carrying Capacity");
+        const capacityPerUserField = screen.getByLabelText("Capacity Per User");
         const aboveCapacityHealthUpdateStrategyField = screen.getByLabelText("When above capacity");
         const belowCapacityHealthUpdateStrategyField = screen.getByLabelText("When below capacity");
         const showLeaderboardField = screen.getByLabelText("Show Leaderboard?");
@@ -99,6 +101,7 @@ describe("AdminCreateCommonsPage tests", () => {
         fireEvent.change(startDateField, { target: { value: '2022-03-05' } })
         fireEvent.change(degradationRateField, { target: { value: '30.4' } })
         fireEvent.change(carryingCapacityField, { target: { value: '25' } })
+        fireEvent.change(capacityPerUserField, { target: { value: '26' } })
         fireEvent.change(showLeaderboardField, { target: { value: true } })
 
         fireEvent.change(aboveCapacityHealthUpdateStrategyField, { target: {value: 'strat2' } })
@@ -119,6 +122,7 @@ describe("AdminCreateCommonsPage tests", () => {
             startingDate: '2022-03-05T00:00:00.000Z', // [1]
             degradationRate: 30.4,
             carryingCapacity: 25,
+            capacityPerUser: 26,
             showLeaderboard: false,
             aboveCapacityHealthUpdateStrategy: "strat2",
             belowCapacityHealthUpdateStrategy: "strat3",
@@ -132,6 +136,7 @@ describe("AdminCreateCommonsPage tests", () => {
             <br />startDate: 2022-03-05T00:00:00
             <br />cowPrice: 10
             <br />carryingCapacity: 25
+            <br />capacityPerUser: 26
         </div>);
 
         expect(mockedNavigate).toBeCalledWith({"to": "/"});

--- a/frontend/src/tests/pages/AdminEditCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminEditCommonsPage.test.js
@@ -51,6 +51,7 @@ describe("AdminEditCommonsPage tests", () => {
                 "milkPrice": 10,
                 "degradationRate": 20.3,
                 "carryingCapacity": 100,
+                "capacityPerUser": 105,
                 "showLeaderboard": false,
                 "aboveCapacityHealthUpdateStrategy": "strat1",
                 "belowCapacityHealthUpdateStrategy": "strat2"
@@ -64,6 +65,7 @@ describe("AdminEditCommonsPage tests", () => {
                 "milkPrice": 5,
                 "degradationRate": 40.3,
                 "carryingCapacity": 200,
+                "capacityPerUser": 210,
                 "showLeaderboard": false,
                 "aboveCapacityHealthUpdateStrategy": "strat2",
                 "belowCapacityHealthUpdateStrategy": "strat3"
@@ -99,6 +101,7 @@ describe("AdminEditCommonsPage tests", () => {
             const startingDateField = screen.getByLabelText(/Starting Date/);
             const degradationRateField = screen.getByLabelText(/Degradation Rate/);
             const carryingCapacityField = screen.getByLabelText(/Carrying Capacity/);
+            const capacityPerUserField = screen.getByLabelText(/Capacity Per User/);
             const aboveCapacityHealthUpdateStrategyField = screen.getByLabelText(/When above capacity/);
             const belowCapacityHealthUpdateStrategyField = screen.getByLabelText(/When below capacity/);
             const showLeaderboardField = screen.getByLabelText(/Show Leaderboard\?/);
@@ -110,6 +113,7 @@ describe("AdminEditCommonsPage tests", () => {
             expect(milkPriceField).toHaveValue(10);
             expect(degradationRateField).toHaveValue(20.3);
             expect(carryingCapacityField).toHaveValue(100);
+            expect(capacityPerUserField).toHaveValue(105);
             expect(aboveCapacityHealthUpdateStrategyField).toHaveValue("strat1");
             expect(belowCapacityHealthUpdateStrategyField).toHaveValue("strat2");
             expect(showLeaderboardField).not.toBeChecked();
@@ -133,6 +137,7 @@ describe("AdminEditCommonsPage tests", () => {
             const startingDateField = screen.getByLabelText(/Starting Date/);
             const degradationRateField = screen.getByLabelText(/Degradation Rate/);
             const carryingCapacityField = screen.getByLabelText(/Carrying Capacity/);
+            const capacityPerUserField = screen.getByLabelText(/Capacity Per User/);
             const aboveCapacityHealthUpdateStrategyField = screen.getByLabelText(/When above capacity/);
             const belowCapacityHealthUpdateStrategyField = screen.getByLabelText(/When below capacity/);
             const showLeaderboardField = screen.getByLabelText(/Show Leaderboard\?/);
@@ -144,6 +149,7 @@ describe("AdminEditCommonsPage tests", () => {
             expect(milkPriceField).toHaveValue(10);
             expect(degradationRateField).toHaveValue(20.3);
             expect(carryingCapacityField).toHaveValue(100);
+            expect(capacityPerUserField).toHaveValue(105);
             expect(aboveCapacityHealthUpdateStrategyField).toHaveValue("strat1");
             expect(belowCapacityHealthUpdateStrategyField).toHaveValue("strat2");
             expect(showLeaderboardField).not.toBeChecked();
@@ -159,6 +165,7 @@ describe("AdminEditCommonsPage tests", () => {
             fireEvent.change(milkPriceField, { target: { value: 5 } })
             fireEvent.change(degradationRateField, { target: { value: 40.3 } })
             fireEvent.change(carryingCapacityField, { target: { value: 200 } })
+            fireEvent.change(capacityPerUserField, { target: { value: 210 } })
             fireEvent.change(aboveCapacityHealthUpdateStrategyField, { target: { value: "strat2" } })
             fireEvent.change(belowCapacityHealthUpdateStrategyField, { target: { value: "strat3" } })
             fireEvent.click(showLeaderboardField)
@@ -179,6 +186,7 @@ describe("AdminEditCommonsPage tests", () => {
                 "startingDate": "2022-03-07T00:00:00.000Z",
                 "degradationRate": 40.3,
                 "carryingCapacity": 200,
+                "capacityPerUser": 210,
                 "aboveCapacityHealthUpdateStrategy": "strat2",
                 "belowCapacityHealthUpdateStrategy": "strat3",
                 "showLeaderboard": true,

--- a/frontend/src/tests/pages/LeaderboardPage.test.js
+++ b/frontend/src/tests/pages/LeaderboardPage.test.js
@@ -165,7 +165,6 @@ describe("LeaderboardPage tests", () => {
         expect(await screen.findByText("Total Wealth")).toBeInTheDocument();
     });
     
-    //#12
     test("that navigate(-1) is called when Back is clicked", async () => {
         setupUser();
         axiosMock.onGet("/api/commons", { params: { id: 1 } }).reply(200, {

--- a/frontend/src/tests/pages/LeaderboardPage.test.js
+++ b/frontend/src/tests/pages/LeaderboardPage.test.js
@@ -1,4 +1,4 @@
-import { screen, waitFor, render } from "@testing-library/react";
+import { screen, waitFor, render, fireEvent } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import axios from "axios";
@@ -164,5 +164,36 @@ describe("LeaderboardPage tests", () => {
         });
         expect(await screen.findByText("Total Wealth")).toBeInTheDocument();
     });
+    
+    //#12
+    test("that navigate(-1) is called when Back is clicked", async () => {
+        setupUser();
+        axiosMock.onGet("/api/commons", { params: { id: 1 } }).reply(200, {
+            "id": 1,
+            "name": "Anika's Commons",
+            "day": 5,
+            "startingDate": "2026-03-05T15:50:10",
+            "startingBalance": 200.50,
+            "totalPlayers": 50,
+            "cowPrice": 15,
+            "milkPrice": 10,
+            "degradationRate": .5,
+            "showLeaderboard": true,
+        });
+        axiosMock.onGet("/api/usercommons/commons/all", { params: { commonsId: 1} }).reply(200,[]);
+        const queryClient = new QueryClient();
+        render(
+            <QueryClientProvider client={queryClient}>
+            <   MemoryRouter>
+                    <LeaderboardPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        expect(await screen.findByTestId(`Leaderboard-back`)).toBeInTheDocument();
+        const backButton = screen.getByTestId(`Leaderboard-back`);
 
+        fireEvent.click(backButton);
+
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith(-1));
+    });
 });

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -86,7 +86,7 @@ public class CommonsController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PutMapping("/update")
     public ResponseEntity<String> updateCommons(
-            @Parameter(name="commons identifier") @RequestParam long id,
+            @Parameter(name="id") @RequestParam long id,
             @Parameter(name="request body") @RequestBody CreateCommonsParams params
     ) {
         Optional<Commons> existing = commonsRepository.findById(id);
@@ -110,7 +110,6 @@ public class CommonsController extends ApiController {
         updated.setShowLeaderboard(params.getShowLeaderboard());
         updated.setDegradationRate(params.getDegradationRate());
         updated.setCarryingCapacity(params.getCarryingCapacity());
-        //#8
         updated.setCapacityPerUser(params.getCapacityPerUser());
 
         if (params.getAboveCapacityHealthUpdateStrategy() != null) {
@@ -157,7 +156,6 @@ public class CommonsController extends ApiController {
                 .degradationRate(params.getDegradationRate())
                 .showLeaderboard(params.getShowLeaderboard())
                 .carryingCapacity(params.getCarryingCapacity())
-                //#8
                 .capacityPerUser(params.getCapacityPerUser());
 
         // ok to set null values for these, so old backend still works

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -110,6 +110,9 @@ public class CommonsController extends ApiController {
         updated.setShowLeaderboard(params.getShowLeaderboard());
         updated.setDegradationRate(params.getDegradationRate());
         updated.setCarryingCapacity(params.getCarryingCapacity());
+        //#8
+        updated.setCapacityPerUser(params.getCapacityPerUser());
+
         if (params.getAboveCapacityHealthUpdateStrategy() != null) {
             updated.setAboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.valueOf(params.getAboveCapacityHealthUpdateStrategy()));
         }
@@ -153,7 +156,9 @@ public class CommonsController extends ApiController {
                 .startingDate(params.getStartingDate())
                 .degradationRate(params.getDegradationRate())
                 .showLeaderboard(params.getShowLeaderboard())
-                .carryingCapacity(params.getCarryingCapacity());
+                .carryingCapacity(params.getCarryingCapacity())
+                //#8
+                .capacityPerUser(params.getCapacityPerUser());
 
         // ok to set null values for these, so old backend still works
         if (params.getAboveCapacityHealthUpdateStrategy() != null) {

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -28,11 +28,8 @@ public class Commons {
     private double startingBalance;
     private LocalDateTime startingDate;
     private boolean showLeaderboard;
-
-    private int carryingCapacity;
     private double degradationRate;
-
-    //#8
+    private int carryingCapacity;
     private int capacityPerUser;
 
     // these defaults match old behavior
@@ -47,4 +44,5 @@ public class Commons {
     @OneToMany(mappedBy = "commons", cascade = CascadeType.REMOVE)
     @JsonIgnore
     private List<UserCommons> joinedUsers;
+
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -32,6 +32,9 @@ public class Commons {
     private int carryingCapacity;
     private double degradationRate;
 
+    //#8
+    private int capacityPerUser;
+
     // these defaults match old behavior
     @Enumerated(EnumType.STRING)
     @Builder.Default

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
@@ -26,8 +26,6 @@ public class CreateCommonsParams {
     private int carryingCapacity;
     @NumberFormat
     private double degradationRate;
-
-    //#8
     @NumberFormat
     private int capacityPerUser;
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
@@ -27,6 +27,10 @@ public class CreateCommonsParams {
     @NumberFormat
     private double degradationRate;
 
+    //#8
+    @NumberFormat
+    private int capacityPerUser;
+
     private String aboveCapacityHealthUpdateStrategy;
     private String belowCapacityHealthUpdateStrategy;
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -66,6 +66,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(105)
                 .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant)
                 .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
                 .build();
@@ -79,6 +80,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(105)
                 .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant.name())
                 .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear.name())
                 .build();
@@ -117,6 +119,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(105)
                 .build();
 
         CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -128,6 +131,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(105)
                 .build();
 
         // don't include null values to simulate old frontend
@@ -167,6 +171,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(105)
                 .build();
 
         CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -178,6 +183,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(105)
                 .build();
 
         String requestBody = objectMapper.writeValueAsString(parameters);
@@ -213,6 +219,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingDate(someTime)
                 .degradationRate(-8.49)
                 .carryingCapacity(100)
+                .capacityPerUser(105)
                 .build();
 
         CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -223,6 +230,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingDate(someTime)
                 .degradationRate(-8.49)
                 .carryingCapacity(100)
+                .capacityPerUser(105)
                 .build();
 
         String requestBody = objectMapper.writeValueAsString(parameters);
@@ -273,6 +281,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(true)
                 .carryingCapacity(100)
+                .capacityPerUser(105)
                 .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant.name())
                 .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear.name())
                 .build();
@@ -286,6 +295,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(true)
                 .carryingCapacity(100)
+                .capacityPerUser(105)
                 .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant)
                 .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
                 .build();
@@ -312,6 +322,8 @@ public class CommonsControllerTests extends ControllerTestCase {
         commons.setShowLeaderboard(parameters.getShowLeaderboard());
         parameters.setCarryingCapacity(123);
         commons.setCarryingCapacity(parameters.getCarryingCapacity());
+        parameters.setCapacityPerUser(124);
+        commons.setCapacityPerUser(parameters.getCapacityPerUser());
         parameters.setAboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear.name());
         commons.setAboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear);
         parameters.setBelowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Noop.name());
@@ -349,6 +361,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(true)
                 .carryingCapacity(100)
+                .capacityPerUser(105)
                 .build();
 
         Commons commons = Commons.builder()
@@ -360,6 +373,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(true)
                 .carryingCapacity(100)
+                .capacityPerUser(105)
                 .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant)
                 .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
                 .build();
@@ -401,6 +415,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(8.49)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(105)
                 .build();
 
         Commons commons = Commons.builder()
@@ -412,6 +427,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(8.49)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(105)
                 .build();
 
         String requestBody = objectMapper.writeValueAsString(parameters);
@@ -434,6 +450,8 @@ public class CommonsControllerTests extends ControllerTestCase {
         commons.setDegradationRate(parameters.getDegradationRate());
         parameters.setCarryingCapacity(123);
         commons.setCarryingCapacity(parameters.getCarryingCapacity());
+        parameters.setCapacityPerUser(124);
+        commons.setCapacityPerUser(parameters.getCapacityPerUser());
 
         requestBody = objectMapper.writeValueAsString(parameters);
 
@@ -467,6 +485,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(8.49)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(105)
                 .build();
 
         Commons commons = Commons.builder()
@@ -478,6 +497,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(8.49)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(105)
                 .build();
 
         String requestBody = objectMapper.writeValueAsString(parameters);
@@ -718,6 +738,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .degradationRate(50.0)
                 .showLeaderboard(false)
                 .carryingCapacity(100)
+                .capacityPerUser(105)
                 .build();
 
         when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));


### PR DESCRIPTION
<img width="911" alt="image" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-2/assets/92049059/fa22e850-512e-4eb3-a1f6-50e5233c7973">
<img width="470" alt="image" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-2/assets/92049059/8f8e2e25-c4ae-49de-8776-2dd46712fcfc">
<img width="427" alt="image" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-2/assets/92049059/a8032a8f-5a58-4b04-bcf3-b845c0309f68">

Added new field ```capacityPerUser``` in Commons class. This field shows up on the ```admin/listcommons``` page, and you can decide the value when creating/editing the page. This value currently does nothing, and is used to compute the value of another field which I will implement in issue #29 

Test: go to the dokku link > create commons and confirm you can input the new field > admin > list commons > hit edit to confirm you can edit new field

Dokku: (https://proj-happycows-rockygao2020-alt.dokku-05.cs.ucsb.edu)

Closes #28 
Part 1 of #8 