### PR TITLE
ka - makes automatic jobs only run on in-progress commons

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/InstructorReportJob.java
@@ -24,6 +24,10 @@ public class InstructorReportJob implements JobContextConsumer {
         Iterable<Commons> allCommons = commonsRepository.findAll();
 
         for (Commons commons : allCommons) {
+            if (!commons.gameInProgress()) {
+                ctx.log("Skipping Producing Report for Commons: " + commons.getName() + " because game is not in progress");
+                continue;
+            }
             ctx.log(String.format("Starting Commons id=%d (%s)...", commons.getId(), commons.getName()));
             Report report = reportService.createReport(commons.getId());
             ctx.log(String.format("Report %d for commons id=%d (%s) finished.", report.getId(), commons.getId(),

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
@@ -1,7 +1,6 @@
 package edu.ucsb.cs156.happiercows.jobs;
 
 import java.time.LocalDateTime;
-
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.Profit;
 import edu.ucsb.cs156.happiercows.entities.User;
@@ -38,6 +37,10 @@ public class MilkTheCowsJob implements JobContextConsumer {
         Iterable<Commons> allCommons = commonsRepository.findAll();
 
         for (Commons commons : allCommons) {
+            if (!commons.gameInProgress()) {
+                ctx.log("Skipping Milking Cows at Commons: " + commons.getName() + " because game is not in progress");
+                continue;
+            }
             String name = commons.getName();
             double milkPrice = commons.getMilkPrice();
             ctx.log("Milking cows for Commons: " + name + ", Milk Price: " + formatDollars(milkPrice));

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -29,6 +29,10 @@ public class UpdateCowHealthJob implements JobContextConsumer {
         Iterable<Commons> allCommons = commonsRepository.findAll();
 
         for (Commons commons : allCommons) {
+            if (!commons.gameInProgress()) {
+                ctx.log("Skipping Cow Health Update at Commons: " + commons.getName() + " because game is not in progress");
+                continue;
+            }
             ctx.log("Commons " + commons.getName() + ", degradationRate: " + commons.getDegradationRate() + ", carryingCapacity: " + commons.getCarryingCapacity());
             int numUsers = commonsRepository.getNumUsers(commons.getId()).orElseThrow(() -> new RuntimeException("Error calling getNumUsers(" + commons.getId() + ")"));
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
@@ -52,7 +52,22 @@ public class UpdateCowHealthJobTests {
                         .cowPrice(10)
                         .milkPrice(2)
                         .startingBalance(300)
-                        .startingDate(LocalDateTime.now())
+                        .startingDate(LocalDateTime.now().minusDays(30))
+                        .lastdayDate(LocalDateTime.now().plusDays(30))
+                        .carryingCapacity(100)
+                        .degradationRate(1)
+                        .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Noop)
+                        .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Noop)
+                        .build();
+        
+        private final Commons pastCommons = Commons
+                        .builder()
+                        .name("past commons")
+                        .cowPrice(10)
+                        .milkPrice(2)
+                        .startingBalance(300)
+                        .startingDate(LocalDateTime.now().minusDays(60))
+                        .lastdayDate(LocalDateTime.now().minusDays(30))
                         .carryingCapacity(100)
                         .degradationRate(1)
                         .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Noop)
@@ -306,6 +321,24 @@ public class UpdateCowHealthJobTests {
                                 Updating cow health...
                                 Commons test commons, degradationRate: 1.0, carryingCapacity: 100
                                 No users in this commons, skipping
+                                Cow health has been updated!""";
+
+                assertEquals(expected, job.getLog());
+        }
+
+        @Test
+        void test_skipping_job_when_commons_not_active() throws Exception {
+
+                pastCommons.setBelowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear);
+
+                when(commonsRepository.findAll()).thenReturn(List.of(pastCommons));
+                when(commonsRepository.getNumUsers(pastCommons.getId())).thenReturn(Optional.of(0));
+
+                runUpdateCowHealthJob();
+
+                String expected = """
+                                Updating cow health...
+                                Skipping Cow Health Update at Commons: past commons because game is not in progress
                                 Cow health has been updated!""";
 
                 assertEquals(expected, job.getLog());


### PR DESCRIPTION
Makes automatic MilkCowsJob, InstructorReportJob, and UpdateHealthJob consider the timeline of each commons so that they skip over the games that have already finished or haven't even yet started. The instructor can still run those jobs on a particular commons through specific singular commons update methods.

To test: go to my dokku -> create a commons in the present, in the past, and in the future -> manually run milking and health update jobs -> see the logs

Deployed on: https://proj-happycows-kirrarista.dokku-05.cs.ucsb.edu/

<img width="1395" alt="image" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-2/assets/77711406/8dbc4ad4-744e-408b-9064-578c2d4cc470">

(still able to run via "produce report for specific commons" even for the commons in the past)
<img width="1299" alt="image" src="https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-2/assets/77711406/ba142873-d1a6-4491-9d5d-f9aa5ac01869">



Closes #47
Closes #10 