### PR TITLE
RG - Part 2 of Issue #8; added effectiveCapacity that shows up on frontend; does not affect Health Formulas yet.

### DIFF
--- a/frontend/src/fixtures/commonsFixtures.js
+++ b/frontend/src/fixtures/commonsFixtures.js
@@ -14,7 +14,7 @@ const commonsFixtures = {
             "showLeaderboard": true,
             "carryingCapacity": 100,
             "capacityPerUser": 105,
-            "effectiveCapacity": 1050,
+            "effectiveCapacity": 5250,
             "belowCapacityHealthUpdateStrategy": "Noop",
             "aboveCapacityHealthUpdateStrategy": "Noop"
         },
@@ -32,7 +32,7 @@ const commonsFixtures = {
             "showLeaderboard": true,
             "carryingCapacity": 123,
             "capacityPerUser": 110,
-            "effectiveCapacity": 1100,
+            "effectiveCapacity": 5500,
             "belowCapacityHealthUpdateStrategy": "Linear",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -50,7 +50,7 @@ const commonsFixtures = {
             "showLeaderboard": true,
             "carryingCapacity": 42,
             "capacityPerUser": 115,
-            "effectiveCapacity": 1150,
+            "effectiveCapacity": 5750,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         }
@@ -70,7 +70,7 @@ const commonsFixtures = {
             "showLeaderboard": true,
             "carryingCapacity": 314,
             "capacityPerUser": 120,
-            "effectiveCapacity": 1200,
+            "effectiveCapacity": 6000,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         }
@@ -86,7 +86,7 @@ const commonsFixtures = {
             "showLeaderboard": true,
             "carryingCapacity": 100,
             "capacityPerUser": 125,
-            "effectiveCapacity": 1250,
+            "effectiveCapacity": 6250,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -100,7 +100,7 @@ const commonsFixtures = {
             "showLeaderboard": true,
             "carryingCapacity": 100,
             "capacityPerUser": 130,
-            "effectiveCapacity": 1300,
+            "effectiveCapacity": 6500,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -114,7 +114,7 @@ const commonsFixtures = {
             "showLeaderboard": true,
             "carryingCapacity": 100,
             "capacityPerUser": 135,
-            "effectiveCapacity": 1350,
+            "effectiveCapacity": 6750,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -128,7 +128,7 @@ const commonsFixtures = {
             "showLeaderboard": true,
             "carryingCapacity": 100,
             "capacityPerUser": 140,
-            "effectiveCapacity": 1400,
+            "effectiveCapacity": 7000,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -142,7 +142,7 @@ const commonsFixtures = {
             "showLeaderboard": true,
             "carryingCapacity": 100,
             "capacityPerUser": 145,
-            "effectiveCapacity": 1450,
+            "effectiveCapacity": 7250,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -156,7 +156,7 @@ const commonsFixtures = {
             "showLeaderboard": true,
             "carryingCapacity": 100,
             "capacityPerUser": 150,
-            "effectiveCapacity": 1500,
+            "effectiveCapacity": 7500,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -170,7 +170,7 @@ const commonsFixtures = {
             "showLeaderboard": true,
             "carryingCapacity": 100,
             "capacityPerUser": 155,
-            "effectiveCapacity": 1550,
+            "effectiveCapacity": 7750,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         }

--- a/frontend/src/fixtures/commonsFixtures.js
+++ b/frontend/src/fixtures/commonsFixtures.js
@@ -55,28 +55,26 @@ const commonsFixtures = {
             "aboveCapacityHealthUpdateStrategy": "Linear"
         }
     ],
-    oneCommons:
-        [
-            {
-                "id": 1,
-                "name": "Anika's Commons",
-                "day": 5,
-                "startingDate": "2025-03-05T15:50:10",
-                "lastdayDate": "2025-04-05T15:50:10",
-                "startingBalance": 2000.50,
-                "totalPlayers": 50,
-                "cowPrice": 15,
-                "milkPrice": 10,
-                "degradationRate": .5,
-                "showLeaderboard": true,
-                "carryingCapacity": 314,
-                "capacityPerUser": 120,
-                "effectiveCapacity": 1200,
-                "belowCapacityHealthUpdateStrategy": "Constant",
-                "aboveCapacityHealthUpdateStrategy": "Linear"
-            }
-        ],
-
+    oneCommons: [
+        {
+            "id": 1,
+            "name": "Anika's Commons",
+            "day": 5,
+            "startingDate": "2025-03-05T15:50:10",
+            "lastdayDate": "2025-04-05T15:50:10",
+            "startingBalance": 2000.50,
+            "totalPlayers": 50,
+            "cowPrice": 15,
+            "milkPrice": 10,
+            "degradationRate": .5,
+            "showLeaderboard": true,
+            "carryingCapacity": 314,
+            "capacityPerUser": 120,
+            "effectiveCapacity": 1200,
+            "belowCapacityHealthUpdateStrategy": "Constant",
+            "aboveCapacityHealthUpdateStrategy": "Linear"
+        }
+    ],
     sevenCommons: [
         {
             "id": 10,

--- a/frontend/src/fixtures/commonsFixtures.js
+++ b/frontend/src/fixtures/commonsFixtures.js
@@ -14,6 +14,7 @@ const commonsFixtures = {
             "showLeaderboard": true,
             "carryingCapacity": 100,
             "capacityPerUser": 105,
+            "effectiveCapacity": 1050,
             "belowCapacityHealthUpdateStrategy": "Noop",
             "aboveCapacityHealthUpdateStrategy": "Noop"
         },
@@ -31,6 +32,7 @@ const commonsFixtures = {
             "showLeaderboard": true,
             "carryingCapacity": 123,
             "capacityPerUser": 110,
+            "effectiveCapacity": 1100,
             "belowCapacityHealthUpdateStrategy": "Linear",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -48,6 +50,7 @@ const commonsFixtures = {
             "showLeaderboard": true,
             "carryingCapacity": 42,
             "capacityPerUser": 115,
+            "effectiveCapacity": 1150,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         }
@@ -68,6 +71,7 @@ const commonsFixtures = {
                 "showLeaderboard": true,
                 "carryingCapacity": 314,
                 "capacityPerUser": 120,
+                "effectiveCapacity": 1200,
                 "belowCapacityHealthUpdateStrategy": "Constant",
                 "aboveCapacityHealthUpdateStrategy": "Linear"
             }
@@ -84,6 +88,7 @@ const commonsFixtures = {
             "showLeaderboard": true,
             "carryingCapacity": 100,
             "capacityPerUser": 125,
+            "effectiveCapacity": 1250,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -97,6 +102,7 @@ const commonsFixtures = {
             "showLeaderboard": true,
             "carryingCapacity": 100,
             "capacityPerUser": 130,
+            "effectiveCapacity": 1300,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -110,6 +116,7 @@ const commonsFixtures = {
             "showLeaderboard": true,
             "carryingCapacity": 100,
             "capacityPerUser": 135,
+            "effectiveCapacity": 1350,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -123,6 +130,7 @@ const commonsFixtures = {
             "showLeaderboard": true,
             "carryingCapacity": 100,
             "capacityPerUser": 140,
+            "effectiveCapacity": 1400,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -136,6 +144,7 @@ const commonsFixtures = {
             "showLeaderboard": true,
             "carryingCapacity": 100,
             "capacityPerUser": 145,
+            "effectiveCapacity": 1450,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -149,6 +158,7 @@ const commonsFixtures = {
             "showLeaderboard": true,
             "carryingCapacity": 100,
             "capacityPerUser": 150,
+            "effectiveCapacity": 1500,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         },
@@ -162,6 +172,7 @@ const commonsFixtures = {
             "showLeaderboard": true,
             "carryingCapacity": 100,
             "capacityPerUser": 155,
+            "effectiveCapacity": 1550,
             "belowCapacityHealthUpdateStrategy": "Constant",
             "aboveCapacityHealthUpdateStrategy": "Linear"
         }

--- a/frontend/src/fixtures/commonsPlusFixtures.js
+++ b/frontend/src/fixtures/commonsPlusFixtures.js
@@ -51,7 +51,7 @@ const commonsPlusFixtures = {
                 "showLeaderboard": true,
                 "carryingCapacity": 123,
                 "capacityPerUser": 115,
-                "effectiveCapacity": 123,
+                "effectiveCapacity": 115,
             },
             "totalCows": 0,
             "totalUsers": 1
@@ -73,7 +73,7 @@ const commonsPlusFixtures = {
                 "showLeaderboard": false,
                 "carryingCapacity": 23,
                 "capacityPerUser": 120,
-                "effectiveCapacity": 23,
+                "effectiveCapacity": 0,
             },
             "totalCows": 0,
             "totalUsers": 0

--- a/frontend/src/fixtures/commonsPlusFixtures.js
+++ b/frontend/src/fixtures/commonsPlusFixtures.js
@@ -51,7 +51,7 @@ const commonsPlusFixtures = {
                 "showLeaderboard": true,
                 "carryingCapacity": 123,
                 "capacityPerUser": 115,
-                "effectiveCapacity": 115,
+                "effectiveCapacity": 123,
             },
             "totalCows": 0,
             "totalUsers": 1
@@ -73,7 +73,7 @@ const commonsPlusFixtures = {
                 "showLeaderboard": false,
                 "carryingCapacity": 23,
                 "capacityPerUser": 120,
-                "effectiveCapacity": 0,
+                "effectiveCapacity": 23,
             },
             "totalCows": 0,
             "totalUsers": 0

--- a/frontend/src/fixtures/commonsPlusFixtures.js
+++ b/frontend/src/fixtures/commonsPlusFixtures.js
@@ -13,6 +13,7 @@ const commonsPlusFixtures = {
                 "showLeaderboard": false,
                 "carryingCapacity": 100,
                 "capacityPerUser": 105,
+                "effectiveCapacity": 210,
             },
             "totalCows": 10,
             "totalUsers": 2
@@ -31,6 +32,7 @@ const commonsPlusFixtures = {
                 "showLeaderboard": true,
                 "carryingCapacity": 42,
                 "capacityPerUser": 110,
+                "effectiveCapacity": 110,
             },
             "totalCows": 0,
             "totalUsers": 1
@@ -49,6 +51,7 @@ const commonsPlusFixtures = {
                 "showLeaderboard": true,
                 "carryingCapacity": 123,
                 "capacityPerUser": 115,
+                "effectiveCapacity": 123,
             },
             "totalCows": 0,
             "totalUsers": 1
@@ -70,6 +73,7 @@ const commonsPlusFixtures = {
                 "showLeaderboard": false,
                 "carryingCapacity": 23,
                 "capacityPerUser": 120,
+                "effectiveCapacity": 23,
             },
             "totalCows": 0,
             "totalUsers": 0

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -93,6 +93,11 @@ export default function CommonsTable({ commons, currentUser }) {
             Header: 'Capacity Per User',
             accessor: row => row.commons.capacityPerUser,
             id: 'commons.capacityPerUser'
+        },
+        {
+            Header: 'Effective Capacity',
+            accessor: row => row.commons.effectiveCapacity,
+            id: 'commons.effectiveCapacity'
         }
     ];
 

--- a/frontend/src/tests/components/Commons/CommonsTable.test.js
+++ b/frontend/src/tests/components/Commons/CommonsTable.test.js
@@ -69,8 +69,9 @@ describe("UserTable tests", () => {
 
     );
 
-    const expectedHeaders = ["id", "Name", "Cow Price", 'Milk Price', 'Starting Balance', 'Starting Date', 'Last Day Date', 'Degradation Rate', 'Carrying Capacity', 'Capacity Per User', 'Cows', 'Show Leaderboard?'];
-    const expectedFields = ["id", "name", "cowPrice", "milkPrice", "startingBalance", "startingDate", "lastdayDate", "degradationRate", "carryingCapacity", "capacityPerUser"];
+
+    const expectedHeaders = ["id", "Name", "Cow Price", 'Milk Price', 'Starting Balance', 'Starting Date',  'Last Day Date', 'Degradation Rate', 'Carrying Capacity', 'Capacity Per User', 'Effective Capacity', 'Cows', 'Show Leaderboard?'];
+    const expectedFields = ["id", "name", "cowPrice", "milkPrice", "startingBalance", "startingDate","lastdayDate", "degradationRate", "carryingCapacity", "capacityPerUser"];
     const testId = "CommonsTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -91,8 +92,10 @@ describe("UserTable tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.cowPrice`)).toHaveTextContent("1");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.milkPrice`)).toHaveTextContent("2");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.degradationRate`)).toHaveTextContent("0.01");
+
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.carryingCapacity`)).toHaveTextContent("42");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.capacityPerUser`)).toHaveTextContent("110");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.effectiveCapacity`)).toHaveTextContent("110");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.startingBalance`)).toHaveTextContent("10");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.startingDate`)).toHaveTextContent(/^2022-11-22$/); // regex so that we have an exact match https://stackoverflow.com/a/73298371
     expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.lastdayDate`)).toHaveTextContent(/^2022-12-22$/);

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -228,7 +228,7 @@ public class CommonsController extends ApiController {
 
         userCommonsRepository.save(uc);
 
-        //#8
+        
         joinedCommons.setNumUsers(joinedCommons.getNumUsers() + 1);
         commonsRepository.save(joinedCommons);
 
@@ -267,7 +267,6 @@ public class CommonsController extends ApiController {
 
         String responseString = String.format("user with id %d deleted from commons with id %d, %d users remain", userId, commonsId, commonsRepository.getNumUsers(commonsId).orElse(0));
 
-        //#8
         Commons exitedCommon = commonsRepository.findById(commonsId).orElse(null);
         exitedCommon.setNumUsers(exitedCommon.getNumUsers() - 1);
         commonsRepository.save(exitedCommon);

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -16,6 +16,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.extern.slf4j.Slf4j;
+
+import org.hibernate.cfg.JoinedSubclassFkSecondPass;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -226,6 +228,10 @@ public class CommonsController extends ApiController {
 
         userCommonsRepository.save(uc);
 
+        //#8
+        joinedCommons.setNumUsers(joinedCommons.getNumUsers() + 1);
+        commonsRepository.save(joinedCommons);
+
         String body = mapper.writeValueAsString(joinedCommons);
         return ResponseEntity.ok().body(body);
     }
@@ -260,6 +266,11 @@ public class CommonsController extends ApiController {
         userCommonsRepository.delete(userCommons);
 
         String responseString = String.format("user with id %d deleted from commons with id %d, %d users remain", userId, commonsId, commonsRepository.getNumUsers(commonsId).orElse(0));
+
+        //#8
+        Commons exitedCommon = commonsRepository.findById(commonsId).orElse(null);
+        exitedCommon.setNumUsers(exitedCommon.getNumUsers() - 1);
+        commonsRepository.save(exitedCommon);
 
         return genericMessage(responseString);
     }

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.happiercows.entities;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
@@ -48,5 +49,14 @@ public class Commons {
     @OneToMany(mappedBy = "commons", cascade = CascadeType.REMOVE)
     @JsonIgnore
     private List<UserCommons> joinedUsers;
+
+    //#8
+    @JsonIgnore
+    private int numUsers;
+
+    @JsonGetter("effectiveCapacity")
+    public int getEffectiveCapacity() {
+        return Math.max(capacityPerUser * numUsers, carryingCapacity);
+    }
 
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -50,7 +50,6 @@ public class Commons {
     @JsonIgnore
     private List<UserCommons> joinedUsers;
 
-    //#8
     @JsonIgnore
     private int numUsers;
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -682,6 +682,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         String cAsJson = mapper.writeValueAsString(c);
 
         assertEquals(responseString, cAsJson);
+        assertEquals(c.getNumUsers(),1);
     }
 
     @WithMockUser(roles = {"USER"})
@@ -815,6 +816,9 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .numOfCows(1)
                 .build();
 
+        //simulating the user being in the common already
+        c.setNumUsers(1);
+        
         String requestBody = mapper.writeValueAsString(uc);
 
         when(userCommonsRepository.findByCommonsIdAndUserId(2L, 1L)).thenReturn(Optional.of(uc));
@@ -833,6 +837,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         String expectedString = "{\"message\":\"user with id 1 deleted from commons with id 2, 0 users remain\"}";
 
         assertEquals(responseString, expectedString);
+        assertEquals(c.getNumUsers(), 0);
     }
 
     @WithMockUser(roles = {"ADMIN"})

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -30,7 +30,9 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -876,4 +878,71 @@ public class CommonsControllerTests extends ControllerTestCase {
         assertEquals(actualCommonsPlus, expectedCommonsPlus);
     }
 
+    //#8 part 2 (effectiveCapacity)
+    //When carryingCapacity > capacityPerUse * numUsers : should return carryingCapacity
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void effectiveCapacityReturnsCarryingCapacity() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+        Commons c = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(50.0)
+                .showLeaderboard(false)
+                .carryingCapacity(100)
+                .capacityPerUser(1)
+                .build();
+
+        c.setNumUsers(99);
+
+        assertEquals(c.getEffectiveCapacity(), 100);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void effectiveCapacityReturnsCapacityPerUser() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+         Commons c = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(50.0)
+                .showLeaderboard(false)
+                .carryingCapacity(100)
+                .capacityPerUser(1)
+                .build();
+
+        c.setNumUsers(101);
+
+        assertEquals(c.getEffectiveCapacity(), 101);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void testCommonsReturnsCarryingCapacityWhenNoUsers() throws Exception {
+        LocalDateTime someTime = LocalDateTime.parse("2022-03-05T15:50:10");
+
+       Commons c = Commons.builder()
+                .name("Jackson's Commons")
+                .cowPrice(500.99)
+                .milkPrice(8.99)
+                .startingBalance(1020.10)
+                .startingDate(someTime)
+                .degradationRate(50.0)
+                .showLeaderboard(false)
+                .carryingCapacity(100)
+                .capacityPerUser(200)
+                .build();
+
+
+        assertEquals(c.getEffectiveCapacity(), 100);
+    }
+      
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -816,7 +816,6 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .numOfCows(1)
                 .build();
 
-        //simulating the user being in the common already
         c.setNumUsers(1);
         
         String requestBody = mapper.writeValueAsString(uc);
@@ -883,8 +882,6 @@ public class CommonsControllerTests extends ControllerTestCase {
         assertEquals(actualCommonsPlus, expectedCommonsPlus);
     }
 
-    //#8 part 2 (effectiveCapacity)
-    //When carryingCapacity > capacityPerUse * numUsers : should return carryingCapacity
     @WithMockUser(roles = {"ADMIN"})
     @Test
     public void effectiveCapacityReturnsCarryingCapacity() throws Exception {


### PR DESCRIPTION
Added new field ```effectiveCapacity = MAX(carryingCapacity, capacityPerUser * numUsers)```

How to Test: Log in > Admin > create Commons > set Carrying Capacity to something low (100) > Set Capacity Per User such that: ```[Capacity Per User] * [# of gmail accounts you have] > Carrying Capacity``` > keep signing in with a new account and going to Admin > list commons > and see the effective capacity eventually exceed the carrying capacity.

Dokku Link: https://proj-happycows-rockygao2020.dokku-05.cs.ucsb.edu/

Example 1: ```[Capacity Per User] * [# of gmail accounts you have(in this case 3)] > Carrying Capacity```
![image](https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-2/assets/92049059/b6e0f108-7175-499c-8277-c50169002e33)

Example 2: ```[Capacity Per User] * [# of gmail accounts you have] < Carrying Capacity```
![image](https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-2/assets/92049059/4c7d7931-461e-43f7-a709-9c6732ed26c1)

Closes #29
Part 2 of #8 
