### PR TITLE
JZ - CommonStats all jobs and avg health and Endpoint

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
@@ -30,6 +30,8 @@ import edu.ucsb.cs156.happiercows.jobs.UpdateCowHealthJobFactory;
 import edu.ucsb.cs156.happiercows.repositories.jobs.JobsRepository;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
 import edu.ucsb.cs156.happiercows.services.jobs.JobService;
+import edu.ucsb.cs156.happiercows.jobs.CommonStatsJob;
+import edu.ucsb.cs156.happiercows.jobs.CommonStatsJobFactory;
 
 
 @Tag(name = "Jobs")
@@ -59,6 +61,9 @@ public class JobsController extends ApiController {
 
     @Autowired
     InstructorReportJobSingleCommonsFactory instructorReportJobSingleCommonsFactory;
+
+    @Autowired
+    CommonStatsJobFactory commonStatsJobFactory;
 
     @Operation(summary = "List all jobs")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
@@ -141,5 +146,14 @@ public class JobsController extends ApiController {
 
         InstructorReportJobSingleCommons instructorReportJobSingleCommons = (InstructorReportJobSingleCommons) instructorReportJobSingleCommonsFactory.create(commonsId);
         return jobService.runAsJob(instructorReportJobSingleCommons);
+    }
+
+    @Operation(summary = "Launch Job to Save Common Stats")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/launch/commonstats")
+    public Job commonStats(
+    ) { 
+        CommonStatsJob commonStatsJob = (CommonStatsJob) commonStatsJobFactory.create();
+        return jobService.runAsJob(commonStatsJob);
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/CommonStatsJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/CommonStatsJob.java
@@ -1,0 +1,65 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import java.time.LocalDateTime;
+
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.Profit;
+import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.ProfitRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
+
+import edu.ucsb.cs156.happiercows.entities.CommonStats;
+import edu.ucsb.cs156.happiercows.repositories.CommonStatsRepository;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+public class CommonStatsJob implements JobContextConsumer {
+
+    @Getter
+    AverageCowHealthService averageCowHealthService;
+
+    @Getter
+    CommonStatsRepository commonStatsRepository;
+
+    @Getter
+    UserCommonsRepository userCommonsRepository;
+
+    @Getter
+    CommonsRepository commonsRepository;
+
+
+    @Override
+    public void accept (JobContext ctx) throws Exception{
+
+        ctx.log("Starting to record commons stats");
+        Iterable<Commons> allCommons = commonsRepository.findAll();
+
+        for(Commons commons: allCommons){
+            long commonId = commons.getId();
+            ctx.log("Starting to record stats for common: " + commons.getName());
+            double avgHealth = averageCowHealthService.getAverageCowHealth(commonId);
+            Iterable<UserCommons> userCommonsList = userCommonsRepository.findByCommonsId(commonId);
+            Integer numCows = 0;
+
+            for(UserCommons userCommons: userCommonsList){
+                numCows += userCommons.getNumOfCows();
+            }
+
+            CommonStats stats = CommonStats.builder()
+            .commonsId(commonId)
+            .numCows(numCows)
+            .avgHealth(avgHealth)
+            .timestamp(LocalDateTime.now())
+            .build();
+
+            commonStatsRepository.save(stats);
+            ctx.log("Saved stats for common: " + commons.getName());
+        }
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/CommonStatsJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/CommonStatsJob.java
@@ -12,6 +12,7 @@ import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
+import edu.ucsb.cs156.happiercows.services.AverageCowHealthService;
 
 import edu.ucsb.cs156.happiercows.entities.CommonStats;
 import edu.ucsb.cs156.happiercows.repositories.CommonStatsRepository;

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/CommonStatsJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/CommonStatsJobFactory.java
@@ -1,0 +1,32 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.CommonStatsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.services.AverageCowHealthService;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
+
+@Service
+public class CommonStatsJobFactory {
+
+    @Autowired
+    private AverageCowHealthService averageCowHealthService;
+
+    @Autowired
+    private CommonStatsRepository commonStatsRepository;
+
+    @Autowired
+    private UserCommonsRepository userCommonsRepository;
+
+    @Autowired
+    private CommonsRepository commonsRepository;
+
+    public JobContextConsumer create() {
+        return new CommonStatsJob(averageCowHealthService, commonStatsRepository, userCommonsRepository, commonsRepository);
+    }
+    
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobs.java
@@ -33,6 +33,9 @@ public class ScheduledJobs {
 
     @Autowired
     MilkTheCowsJobFactory milkTheCowsJobFactory;
+
+    @Autowired
+    CommonStatsJobFactory commonStatsJobFactory;
     
     @Scheduled(cron = "${app.updateCowHealth.cron}", zone = "America/Los_Angeles")
     public void runUpdateCowHealthJobBasedOnCron() {
@@ -53,4 +56,14 @@ public class ScheduledJobs {
     
        log.info("runMilkTheCowsJobBasedOnCron: launched job");
     }
+
+    @Scheduled(cron = "${app.commonStats.cron}", zone = "America/Los_Angeles")
+    public void runCommonStatsJobBasedOnCron() {
+      log.info("runCommonStatsJobBasedOnCron: running");
+
+      JobContextConsumer commonStatsJob = commonStatsJobFactory.create();
+      jobService.runAsJob(commonStatsJob);
+
+      log.info("runCommonStatsJobBasedOnCron: launched job");
+   }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/CommonStatsRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/CommonStatsRepository.java
@@ -7,5 +7,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommonStatsRepository extends CrudRepository<CommonStats, Long> {
-    
+    Iterable<CommonStats> findAllByCommonsId(long commonsId);
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthService.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthService.java
@@ -7,6 +7,7 @@ import edu.ucsb.cs156.happiercows.entities.UserCommons;
 
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 
+@Service
 public class AverageCowHealthService {
 
     @Autowired

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthService.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthService.java
@@ -1,0 +1,31 @@
+package edu.ucsb.cs156.happiercows.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+
+public class AverageCowHealthService {
+
+    @Autowired
+    UserCommonsRepository userCommonsRepository;
+
+    public double getAverageCowHealth(long commonsId) {
+        Iterable<UserCommons> userCommonsList = userCommonsRepository.findByCommonsId(commonsId);
+        double totalHealth = 0.0;
+        int totalCows = 0;
+
+        for(UserCommons userCommons: userCommonsList){
+            totalHealth += userCommons.getCowHealth() * userCommons.getNumOfCows();
+            totalCows += userCommons.getNumOfCows();
+        }
+
+        if(!userCommonsList.iterator().hasNext()){
+            throw new IllegalArgumentException("Unable to get average cow health");
+        }
+
+        return totalCows == 0 ? 0 :totalHealth / totalCows;
+    } 
+}

--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -13,3 +13,4 @@ spring.datasource.initialization-mode=always
 
 app.updateCowHealth.cron=${UPDATE_COW_HEALTH_CRON:${env.UPDATE_COW_HEALTH_CRON:0 */7 * * * *}}
 app.milkTheCows.cron=${MILK_THE_COWS_CRON:${env.MILK_THE_COWS_CRON:0 */13 * * * *}}
+app.commonStats.cron=${COMMON_STATS_CRON:${env.COMMON_STATS_CRON:0 0 0/6 * * ?}}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,4 +35,4 @@ spring.data.mongodb.uri=${MONGODB_URI:${env.MONGODB_URI:mongodb+srv://fakeUserna
 
 app.updateCowHealth.cron=${UPDATE_COW_HEALTH_CRON:${env.UPDATE_COW_HEALTH_CRON:0 0 0,12 * * *}}
 app.milkTheCows.cron=${MILK_THE_COWS_CRON:${env.MILK_THE_COWS_CRON:0 0 4 * * *}}
-
+app.commonStats.cron=${COMMON_STATS_CRON:${env.COMMON_STATS_CRON:0 0 0/6 * * ?}}

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/JobsControllerTests.java
@@ -78,6 +78,9 @@ public class JobsControllerTests extends ControllerTestCase {
         @MockBean
         UserCommonsRepository userCommonsRepository;
 
+        @MockBean 
+        CommonStatsRepository CommonStatsRepository;
+
         @MockBean
         UpdateCowHealthJobFactory updateCowHealthJobFactory;
 
@@ -92,6 +95,9 @@ public class JobsControllerTests extends ControllerTestCase {
 
         @MockBean
         InstructorReportJobSingleCommonsFactory instructorReportJobSingleCommonsFactory;
+
+        @MockBean
+        CommonStatsJobFactory commonStatsJobFactory;
 
         @WithMockUser(roles = { "ADMIN" })
         @Test

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/JobsControllerTests.java
@@ -49,6 +49,9 @@ import edu.ucsb.cs156.happiercows.jobs.SetCowHealthJobFactory;
 import edu.ucsb.cs156.happiercows.jobs.UpdateCowHealthJobFactory;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.jobs.CommonStatsJob;
+import edu.ucsb.cs156.happiercows.jobs.CommonStatsJobFactory;
+import edu.ucsb.cs156.happiercows.repositories.CommonStatsRepository;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -315,5 +318,19 @@ public class JobsControllerTests extends ControllerTestCase {
 
                 assertNotNull(jobReturned.getStatus());
         }
+        
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void admin_can_launch_common_stats_job() throws Exception {
+                // act
+                MvcResult response = mockMvc.perform(post("/api/jobs/launch/commonstats?commmonsId=1").with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
 
+                // assert
+                String responseString = response.getResponse().getContentAsString();
+                log.info("responseString={}", responseString);
+                Job jobReturned = objectMapper.readValue(responseString, Job.class);
+
+                assertNotNull(jobReturned.getStatus());
+        }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/CommonStatsJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/CommonStatsJobFactoryTests.java
@@ -1,0 +1,51 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.ProfitRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.repositories.CommonStatsRepository;
+import edu.ucsb.cs156.happiercows.services.AverageCowHealthService;
+
+@RestClientTest(CommonStatsJobFactory.class)
+@AutoConfigureDataJpa
+public class CommonStatsJobFactoryTests {
+
+    @MockBean
+    CommonsRepository commonsRepository;
+
+    @MockBean
+    UserCommonsRepository userCommonsRepository;
+
+    @MockBean
+    CommonStatsRepository commonStatsRepository;
+
+    @MockBean
+    AverageCowHealthService averageCowHealthService;
+
+    @Autowired
+    CommonStatsJobFactory commonStatsJobFactory;
+
+    @Test
+    void test_create() throws Exception {
+
+        // Act
+        CommonStatsJob commonStatsJob = (CommonStatsJob) commonStatsJobFactory.create();
+
+        // Assert
+        assertEquals(commonsRepository,commonStatsJob.getCommonsRepository());
+        assertEquals(userCommonsRepository,commonStatsJob.getUserCommonsRepository());
+        assertEquals(commonStatsRepository,commonStatsJob.getCommonStatsRepository());
+        assertEquals(averageCowHealthService,commonStatsJob.getAverageCowHealthService());
+
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/CommonStatsJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/CommonStatsJobTests.java
@@ -1,0 +1,129 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.entities.CommonStats;
+import edu.ucsb.cs156.happiercows.entities.jobs.Job;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.ProfitRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.repositories.CommonStatsRepository;
+import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
+import edu.ucsb.cs156.happiercows.services.AverageCowHealthService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import java.time.LocalDateTime;
+
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+public class CommonStatsJobTests {
+    @Mock
+    CommonsRepository commonsRepository;
+
+    @Mock
+    UserCommonsRepository userCommonsRepository;
+
+    @Mock
+    CommonStatsRepository commonStatsRepository;
+
+    @Mock
+    AverageCowHealthService averageCowHealthService;
+
+
+    private User user = User
+            .builder()
+            .id(1L)
+            .fullName("Chris Gaucho")
+            .email("cgaucho@example.org")
+            .build();
+
+    private Commons testCommons = Commons
+            .builder()
+            .name("test commons")
+            .cowPrice(10)
+            .milkPrice(2)
+            .startingBalance(300)
+            .startingDate(LocalDateTime.now())
+            .carryingCapacity(100)
+            .degradationRate(0.01)
+            .build();
+
+    private UserCommons uc_1 = UserCommons
+        .builder()
+        .user(user)
+        .username("Chris Gaucho")
+        .commons(testCommons)
+        .totalWealth(300)
+        .numOfCows(150)
+        .cowHealth(10)
+        .cowsBought(96)
+        .cowsSold(50)
+        .cowDeaths(23)
+        .build();
+
+    private CommonStats expectedCommonStats = CommonStats.builder()
+                .commonsId(testCommons.getId())
+                .numCows(150)
+                .avgHealth(10.0)
+                .build();
+
+
+
+    @Test
+    void test_common_stats() throws Exception{
+        // Arrange
+
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        when(commonsRepository.findAll()).thenReturn(Arrays.asList(testCommons));
+        when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(uc_1));
+        when(averageCowHealthService.getAverageCowHealth(testCommons.getId())).thenReturn(10.0);
+
+
+        // Act
+        CommonStatsJob commonStatsJob = new CommonStatsJob(averageCowHealthService, commonStatsRepository, userCommonsRepository, commonsRepository);
+
+        commonStatsJob.accept(ctx);
+
+        // Assert
+        ArgumentCaptor<CommonStats> captor = ArgumentCaptor.forClass(CommonStats.class);
+        verify(commonStatsRepository).save(captor.capture());
+        CommonStats savedCommonStats = captor.getValue();
+
+
+        assertEquals(expectedCommonStats.getNumCows(), savedCommonStats.getNumCows());
+        assertEquals(expectedCommonStats.getAvgHealth(), savedCommonStats.getAvgHealth()); 
+        assertEquals(expectedCommonStats.getCommonsId(), savedCommonStats.getCommonsId());
+
+        assertThat(savedCommonStats.getTimestamp()).isCloseTo(LocalDateTime.now(), within(5L, ChronoUnit.MINUTES));
+
+        String expected = """
+                Starting to record commons stats
+                Starting to record stats for common: test commons
+                Saved stats for common: test commons""";
+
+        assertEquals(expected, jobStarted.getLog());
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobsTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/ScheduledJobsTests.java
@@ -49,6 +49,9 @@ public class ScheduledJobsTests {
     @MockBean
     private JobService jobService;
 
+    @MockBean
+    CommonStatsJobFactory commonStatsJobFactory;
+
     @Test
     void test_runUpdateCowHealthJobBasedOnCron() throws Exception {
 
@@ -93,5 +96,25 @@ public class ScheduledJobsTests {
 
     }
 
-  
+    @Test
+    void test_runCommonStatsJobBasedOnCron() throws Exception {
+
+        // Arrange
+
+        Job job = Job.builder().build();
+        MockJobContextConsumer mockJob = new MockJobContextConsumer();
+
+       when(commonStatsJobFactory.create()).thenReturn(mockJob);
+       when(jobService.runAsJob(any())).thenReturn(job);
+
+        // Act
+
+        scheduledJobs.runCommonStatsJobBasedOnCron();
+
+        // Assert
+
+        verify(jobService, times(1)).runAsJob(mockJob);
+        verify(commonStatsJobFactory, times(1)).create();
+
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthServiceTest.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/AverageCowHealthServiceTest.java
@@ -1,0 +1,167 @@
+package edu.ucsb.cs156.happiercows.services;
+
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Optional;
+
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.entities.UserCommonsKey;
+import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
+
+
+@ExtendWith(SpringExtension.class)
+@Import(AverageCowHealthService.class)
+@ContextConfiguration
+public class AverageCowHealthServiceTest {
+    @Autowired
+    AverageCowHealthService averageCowHealthService;
+
+    @MockBean 
+    UserCommonsRepository userCommonsRepository;
+
+    private User user1 = User
+      .builder()
+      .id(42L)
+      .fullName("Chris Gaucho")
+      .email("cgaucho@example.org")
+      .build();
+
+    private User user2 = User
+      .builder()
+      .id(43L)
+      .fullName("watermelon")
+      .email("watermelon@example.org")
+      .build();
+
+    private User user3 = User
+      .builder()
+      .id(43L)
+      .fullName("zero")
+      .email("zero@example.org")
+      .build();
+
+  private Commons commons_1 = Commons
+      .builder()
+      .id(17L)
+      .name("test commons 1")
+      .cowPrice(10)
+      .milkPrice(2)
+      .startingBalance(300)
+      .startingDate(LocalDateTime.parse("2022-03-05T15:50:10"))
+      .showLeaderboard(true)
+      .carryingCapacity(100)
+      .degradationRate(0.01)
+      .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
+      .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
+      .build();
+
+    private Commons commons_2 = Commons
+      .builder()
+      .id(18L)
+      .name("test commons 2")
+      .cowPrice(10)
+      .milkPrice(2)
+      .startingBalance(300)
+      .startingDate(LocalDateTime.parse("2022-03-05T15:50:11"))
+      .showLeaderboard(true)
+      .carryingCapacity(100)
+      .degradationRate(0.01)
+      .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
+      .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
+      .build();
+
+  UserCommons uc_1 = UserCommons
+      .builder()
+      .user(user1)
+      .username("Chris Gaucho")
+      .commons(commons_1)
+      .totalWealth(300)
+      .numOfCows(123)
+      .cowHealth(10)
+      .cowsBought(78)
+      .cowsSold(23)
+      .cowDeaths(6)
+      .build();
+
+    UserCommons uc_2 = UserCommons
+      .builder()
+      .user(user2)
+      .username("watermelon")
+      .commons(commons_1)
+      .totalWealth(100)
+      .numOfCows(70)
+      .cowHealth(8)
+      .cowsBought(30)
+      .cowsSold(10)
+      .cowDeaths(7)
+      .build();
+
+
+    UserCommons uc_3 = UserCommons
+      .builder()
+      .user(user3)
+      .username("watermelon")
+      .commons(commons_2)
+      .totalWealth(100)
+      .numOfCows(0)
+      .cowHealth(8)
+      .cowsBought(30)
+      .cowsSold(10)
+      .cowDeaths(7)
+      .build();
+
+    @BeforeEach
+    void setup() {
+        uc_1.setId(new UserCommonsKey(user1.getId(), commons_1.getId()));
+        uc_2.setId(new UserCommonsKey(user2.getId(), commons_1.getId()));
+        uc_3.setId(new UserCommonsKey(user3.getId(), commons_2.getId()));
+    }
+
+    @Test
+    void testGetAverageCowHealth(){
+        when(userCommonsRepository.findByCommonsId(17L)).thenReturn(Arrays.asList(uc_1, uc_2));
+
+        Double avgHealth = averageCowHealthService.getAverageCowHealth(17L);
+
+        Assertions.assertEquals(1790.0/193.0, avgHealth);
+
+    }
+
+    @Test
+    void testGetAverageCowHealth_throwException(){
+        when(userCommonsRepository.findByCommonsId(17L)).thenReturn(Arrays.asList());
+
+        RuntimeException thrown = Assertions.assertThrows(RuntimeException.class, () -> {
+            averageCowHealthService.getAverageCowHealth(17L);
+        }, "RuntimeException was expected");
+
+        String message = thrown.getMessage();
+        String expectedMessage = "Unable to get average cow health";
+        Assertions.assertTrue(message.contains(expectedMessage), String.format("Expected message to contain \"%s\" but was \"%s\"", expectedMessage, message));
+    }
+
+    @Test
+    void testGetAverageCowHealth_zeroCows(){
+        when(userCommonsRepository.findByCommonsId(18L)).thenReturn(Arrays.asList(uc_3));
+
+        Double avgHealth = averageCowHealthService.getAverageCowHealth(18L);
+
+        Assertions.assertEquals(0, avgHealth);
+    }
+}


### PR DESCRIPTION
closes both #53 and #52 and #45 for sake of integration and unit testing. Each of these draft PRs hold links to the original issue.

In this PR, I implement the majority of the backend for our CommonStats feature, which uses CRUD capabilities to track periodic statistics based on Average cow health for select commons, which I had to implement myself separately in the services directory.

Here is a screenshot of the api/Post endpoint on swagger:
![image](https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-2/assets/102626158/6d0cb916-385e-4058-b8e6-521d05ce1448)

Here is the log of the CommonStats Job running on the admin Jobs log on the main dokku instance:
![image](https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-2/assets/102626158/c5c35579-612f-4a28-a757-4ec605d487ae)
