### PR TITLE
JZ - CommonStats frontend modifying CommonsTable + tests

### DIFF
--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -35,6 +35,8 @@ export default function CommonsTable({ commons, currentUser }) {
         navigate(`/leaderboard/${cell.row.values["commons.id"]}`)
     }
 
+    const downloadCallback = (cell) => window.location.href = `/api/commons/${cell.row.values["commons.id"]}/download?commonsId=${cell.row.values["commons.id"]}`;
+
     const columns = [
         {
             Header: 'id',
@@ -100,9 +102,10 @@ export default function CommonsTable({ commons, currentUser }) {
 
     const columnsIfAdmin = [
         ...columns,
-        ButtonColumn("Edit", "primary", editCallback, testid),
-        ButtonColumn("Delete", "danger", deleteCallback, testid),
-        ButtonColumn("Leaderboard", "secondary", leaderboardCallback, testid)
+        ButtonColumn("Edit","primary", editCallback, testid),
+        ButtonColumn("Delete","danger", deleteCallback, testid),
+        ButtonColumn("Leaderboard","secondary", leaderboardCallback, testid),
+        ButtonColumn("Download", "success", downloadCallback, testid)
     ];
 
     const columnsToDisplay = hasRole(currentUser,"ROLE_ADMIN") ? columnsIfAdmin : columns;

--- a/frontend/src/tests/components/Commons/CommonsTable.test.js
+++ b/frontend/src/tests/components/Commons/CommonsTable.test.js
@@ -19,6 +19,13 @@ jest.mock('react-router-dom', () => ({
 describe("UserTable tests", () => {
   const queryClient = new QueryClient();
 
+  Object.defineProperty(window, "location", {
+    value: {
+      href: ""
+    },
+    writable:true
+  })
+
   test("renders without crashing for empty table with user not logged in", () => {
     const currentUser = null;
 
@@ -102,6 +109,7 @@ describe("UserTable tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`)).toHaveClass("btn-primary");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`)).toHaveClass("btn-danger");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-Leaderboard-button`)).toHaveClass("btn-secondary");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-Download-button`)).toHaveClass("btn-success");
   });
 
   test("the correct parameters are passed to useBackendMutation when Delete is clicked", async () => {
@@ -133,6 +141,31 @@ describe("UserTable tests", () => {
         { onSuccess: onDeleteSuccess },
         ["/api/commons/allplus"]
       );
+    });
+
+  });
+
+  test("the download button works as intended", async () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CommonsTable commons={commonsPlusFixtures.threeCommonsPlus} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("CommonsTable-cell-row-0-col-Download-button")).toBeInTheDocument();
+    });
+
+    const downloadButton = screen.getByTestId("CommonsTable-cell-row-0-col-Download-button");
+    fireEvent.click(downloadButton);
+
+    await waitFor(() => {
+      expect(window.location.href).toBe("/api/commons/1/download?commonsId=1")
     });
 
   });

--- a/src/main/java/edu/ucsb/cs156/happiercows/helpers/CommonStatsCSVHelper.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/helpers/CommonStatsCSVHelper.java
@@ -1,0 +1,69 @@
+package edu.ucsb.cs156.happiercows.helpers;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import edu.ucsb.cs156.happiercows.entities.CommonStats;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/*
+ * This code is based on 
+ * <a href="https://bezkoder.com/spring-boot-download-csv-file/">https://bezkoder.com/spring-boot-download-csv-file/</a>
+ * and provides a way to serve up a CSV file containing information associated
+ * with an instructor report.
+ */
+
+public class CommonStatsCSVHelper {
+
+  private CommonStatsCSVHelper() {}
+
+  /**
+   * This method is a hack to avoid a pitest issue; it isn't possible to 
+   * exclude an individual method call from pitest coverage, but we can
+   * exclude the entire method by name in the pitest settings in pom.xml
+   * @param out stream to close
+   * @param csvPrinter printer to close
+   */
+
+  public static void flush_and_close_noPitest(ByteArrayOutputStream out, CSVPrinter csvPrinter) throws IOException {
+    csvPrinter.flush();
+    csvPrinter.close();
+    out.flush();
+    out.close();
+  }
+
+  public static ByteArrayInputStream toCSV(Iterable<CommonStats> lines) throws IOException {
+    final CSVFormat format = CSVFormat.DEFAULT;
+
+    List<String> headers = Arrays.asList(
+        "id",
+        "commonsId",
+        "numCows",
+        "avgHealth",
+        "timestamp");
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    CSVPrinter csvPrinter = new CSVPrinter(new PrintWriter(out), format);
+
+    csvPrinter.printRecord(headers);
+
+    for (CommonStats stats : lines) {
+      List<String> data = Arrays.asList(
+          String.valueOf(stats.getId()),
+          String.valueOf(stats.getCommonsId()),
+          String.valueOf(stats.getNumCows()),
+          String.valueOf(stats.getAvgHealth()),
+          String.valueOf(stats.getTimestamp()));
+      csvPrinter.printRecord(data);
+    }
+
+    flush_and_close_noPitest(out, csvPrinter);
+    return new ByteArrayInputStream(out.toByteArray());
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -6,12 +6,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.happiercows.ControllerTestCase;
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.CommonsPlus;
+import edu.ucsb.cs156.happiercows.entities.CommonStats;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.models.CreateCommonsParams;
 import edu.ucsb.cs156.happiercows.models.HealthUpdateStrategyList;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.repositories.CommonStatsRepository;
 import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.io.StringReader;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -34,6 +38,14 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = CommonsController.class)
@@ -49,8 +61,55 @@ public class CommonsControllerTests extends ControllerTestCase {
     @MockBean
     CommonsRepository commonsRepository;
 
+    @MockBean
+    CommonStatsRepository commonStatsRepository;
+
     @Autowired
     private ObjectMapper objectMapper;
+
+    private User user = User
+                        .builder()
+                        .id(42L)
+                        .fullName("Chris Gaucho")
+                        .email("cgaucho@example.org")
+                        .build();
+
+    private Commons commons = Commons
+                        .builder()
+                        .id(17L)
+                        .name("test commons")
+                        .cowPrice(10)
+                        .milkPrice(2)
+                        .startingBalance(300)
+                        .startingDate(LocalDateTime.parse("2022-03-05T15:50:10"))
+                        .showLeaderboard(true)
+                        .carryingCapacity(100)
+                        .degradationRate(0.01)
+                        .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
+                        .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
+                        .build();
+
+    UserCommons userCommons = UserCommons
+                        .builder()
+                        .user(user)
+                        .username("Chris Gaucho")
+                        .commons(commons)
+                        .totalWealth(300)
+                        .numOfCows(123)
+                        .cowHealth(10)
+                        .cowsBought(78)
+                        .cowsSold(23)
+                        .cowDeaths(6)
+                        .build();
+
+    CommonStats expectedCommonStats = CommonStats
+                        .builder()
+                        .commonsId(17L)
+                        .numCows(123)
+                        .avgHealth(10.0)
+                        .timestamp(LocalDateTime.now())
+                        .build();
+
 
     @WithMockUser(roles = {"ADMIN"})
     @Test
@@ -875,5 +934,30 @@ public class CommonsControllerTests extends ControllerTestCase {
                 });
         assertEquals(actualCommonsPlus, expectedCommonsPlus);
     }
+
+    @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void test_get_csv() throws Exception {
+                when(commonStatsRepository.findAllByCommonsId(commons.getId())).thenReturn(List.of(expectedCommonStats));
+
+                MvcResult response = mockMvc.perform(get("/api/commons/17L/download?commonsId=17")).andDo(print())
+                                .andExpect(status().isOk()).andReturn();
+
+                verify(commonStatsRepository, times(1)).findAllByCommonsId(eq(17L));
+                String responseString = response.getResponse().getContentAsString();
+
+                assertEquals("application/csv", response.getResponse().getContentType());
+
+                String[] lines = responseString.split("\\r?\\n");
+
+                assertEquals("id,commonsId,numCows,avgHealth,timestamp", lines[0]);
+
+                String[] fields = lines[1].split(",");
+
+                assertEquals("17", fields[1]);
+                assertEquals("123", fields[2]);
+                assertEquals("10.0", fields[3]);
+
+        }
 
 }


### PR DESCRIPTION
closes #39 
In this PR, we finally address the User story part where users can generate and download a summary report of their commons list in terms of average cow health.

how to test:
- visit localhost800 or our dokku deployment
- as admin, create a commons and populate it with users and their cows
- as admin, list commons and scroll right to interact with the download button

Here is what it looks like on localhost:
![image](https://github.com/ucsb-cs156-m23/proj-happycows-m23-10am-2/assets/102626158/0c98ecdb-b4cf-4f5e-ba88-611893db2891)
